### PR TITLE
Fix the dependency on the active field.  Sometimes the facts returned…

### DIFF
--- a/src/ansible/get_network_interfaces.yml
+++ b/src/ansible/get_network_interfaces.yml
@@ -23,7 +23,7 @@
         ) and (
           'ansible_' + MGMT_NETWORK not in hostvars[inventory_hostname]
         ) and (
-          hostvars[inventory_hostname]['ansible_' + item]['active']
+          active in hostvars[inventory_hostname]['ansible_' + item] and hostvars[inventory_hostname]['ansible_' + item]['active']
         ) and (
           hostvars[inventory_hostname]['ansible_' + item]['type'] != 'bridge'
         ) and (


### PR DESCRIPTION
… by ansible for secondary interfaces (e.g. ens33:1) don't have the active flag in the data