### PR TITLE
Corrected name of bond mode

### DIFF
--- a/src/ansible/get_network_interfaces.yml
+++ b/src/ansible/get_network_interfaces.yml
@@ -12,7 +12,7 @@
   - debug: var=bridge_interface
   - name: Get all active network interfaces
     vars:
-      acceptable_bond_modes: ['active-backup','balance-xor','broadcast','802.3adq']
+      acceptable_bond_modes: ['active-backup','balance-xor','broadcast','802.3ad']
     set_fact:
       otopi_net_host="{{ item }}"
       type="{{ hostvars[inventory_hostname]['ansible_' + item]['type'] }}"


### PR DESCRIPTION
The bond mode '802.3ad' was incorrectly typed as '802.3adq'