### PR TITLE
fix the pg conf file path to support postgres10

### DIFF
--- a/src/ansible/pg_scl.yml
+++ b/src/ansible/pg_scl.yml
@@ -1,6 +1,6 @@
 ---
 - name: Find configuration file for SCL PostgreSQL
-  shell: ls -vr1 /etc/ovirt-engine/engine.conf.d/*-scl-postgres-*.conf
+  shell: ls -vr1 /etc/ovirt-engine/engine.conf.d/*-scl-postgres*.conf
   environment: "{{ CMD_LANG }}"
   register: scl_pg_conf_flist
   changed_when: True


### PR DESCRIPTION
we are looking for "ls -vr1 /etc/ovirt-engine/engine.conf.d/*-scl-postgres-*.conf" 
because in pg9.5 it was "/etc/ovirt-engine/engine.conf.d/10-scl-postgres-95.conf"
but when we moved to pg10 the file is "/etc/ovirt-engine/engine.conf.d/10-scl-postgres.conf"