### PR TITLE
copr: fix missing suffix in built rpms

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,6 +1,12 @@
-srpm:
+.PHONY: installdeps srpm
+
+installdeps:
 	dnf -y install git autoconf automake make gettext-devel gcc
+
+srpm: installdeps
 	$(eval SUFFIX=$(shell sh -c " echo '.$$(date -u +%Y%m%d%H%M%S).git$$(git rev-parse --short HEAD)'"))
+	# changing the spec file as passing -D won't preserve the suffix when rebuilding in mock
+	sed "s:%{?release_suffix}:${SUFFIX}:" -i *.spec.in
 	mkdir -p tmp.repos/SOURCES
 	autopoint
 	autoreconf -ivf
@@ -8,6 +14,5 @@ srpm:
 	make dist
 	rpmbuild \
 		-D "_topdir tmp.repos" \
-		-D "release_suffix ${SUFFIX}" \
 		-ts ./*.tar.gz
 	cp tmp.repos/SRPMS/*.src.rpm $(outdir)


### PR DESCRIPTION
Change-Id: I65a90f1746fd56373814de6f4f2ed6dea636dcfd
Signed-off-by: Yedidyah Bar David <didi@redhat.com>