### PR TITLE
src: Add an option to choose OpenSCAP security profile name

### DIFF
--- a/ovirt-hosted-engine-setup.spec.in
+++ b/ovirt-hosted-engine-setup.spec.in
@@ -71,7 +71,7 @@ Requires:       virt-install
 # The whole way of consuming anisble roles is going to change
 # skipping ansible dependencies until we have something working.
 Requires:       ansible >= 2.9.21, ansible < 2.10.0
-Requires:       ovirt-ansible-collection >= 1.6.5
+Requires:       ovirt-ansible-collection >= 1.6.7
 %endif
 # default libvirt network
 Requires:       libvirt-daemon-config-network

--- a/src/ovirt_hosted_engine_setup/constants.py
+++ b/src/ovirt_hosted_engine_setup/constants.py
@@ -955,6 +955,12 @@ class CloudInit(object):
     @ohostedattrs(
         answerfile=True,
     )
+    def OPENSCAP_PROFILE_NAME(self):
+        return 'OVEHOSTED_VM/OpenScapProfileName'
+
+    @ohostedattrs(
+        answerfile=True,
+    )
     def ENABLE_FIPS(self):
         return 'OVEHOSTED_VM/enableFips'
 

--- a/src/plugins/gr-he-ansiblesetup/core/misc.py
+++ b/src/plugins/gr-he-ansiblesetup/core/misc.py
@@ -327,6 +327,9 @@ class Plugin(plugin.PluginBase):
             'he_apply_openscap_profile': self.environment[
                 ohostedcons.CloudInit.APPLY_OPENSCAP_PROFILE
             ],
+            'he_openscap_profile_name': self.environment[
+                ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
+            ].lower(),
             'he_enable_fips': self.environment[
                 ohostedcons.CloudInit.ENABLE_FIPS
             ],

--- a/src/plugins/gr-he-common/vm/cloud_init.py
+++ b/src/plugins/gr-he-common/vm/cloud_init.py
@@ -554,6 +554,10 @@ class Plugin(plugin.PluginBase):
             None
         )
         self.environment.setdefault(
+            ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME,
+            None
+        )
+        self.environment.setdefault(
             ohostedcons.CloudInit.ENABLE_FIPS,
             None
         )
@@ -920,7 +924,7 @@ class Plugin(plugin.PluginBase):
                 ] = self.dialog.queryString(
                     name='CI_APPLY_OPENSCAP_PROFILE',
                     note=_(
-                        'Do you want to apply a default OpenSCAP security '
+                        'Do you want to apply an OpenSCAP security '
                         'profile? (@VALUES@) [@DEFAULT@]: '
                     ),
                     prompt=True,
@@ -929,11 +933,34 @@ class Plugin(plugin.PluginBase):
                     default=_('No')
                 ) == _('Yes').lower()
 
+            if (
+                self.environment[
+                    ohostedcons.CloudInit.APPLY_OPENSCAP_PROFILE
+                ] and self.environment[
+                    ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
+                ] is None
+            ):
+                self.environment[
+                    ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
+                ] = self.dialog.queryString(
+                    name='CI_OPENSCAP_PROFILE_NAME',
+                    note=_(
+                        'Please provide the security profile you '
+                        'would like to use (@VALUES@) [@DEFAULT@]: '
+                    ),
+                    prompt=True,
+                    validValues=(_('stig'), _('pci-dss')),
+                    caseSensitive=False,
+                    default='stig',
+                )
+
+            # Skipping this question when OPENSCAP_PROFILE_NAME is stig since
+            # FIPS is enabled by default in a stig profile
             if self.environment[
                 ohostedcons.CloudInit.ENABLE_FIPS
             ] is None and self.environment[
-                ohostedcons.CloudInit.APPLY_OPENSCAP_PROFILE
-            ] is False:
+                ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
+            ] != 'stig':
                 self.environment[
                     ohostedcons.CloudInit.ENABLE_FIPS
                 ] = self.dialog.queryString(

--- a/src/plugins/gr-he-common/vm/cloud_init.py
+++ b/src/plugins/gr-he-common/vm/cloud_init.py
@@ -933,23 +933,21 @@ class Plugin(plugin.PluginBase):
                     default=_('No')
                 ) == _('Yes').lower()
 
-            if (
-                self.environment[
-                    ohostedcons.CloudInit.APPLY_OPENSCAP_PROFILE
-                ] and self.environment[
-                    ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
-                ] is None
-            ):
-                self.environment[
-                    ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
-                ] = self.dialog.queryString(
+            if self.environment[
+                ohostedcons.CloudInit.APPLY_OPENSCAP_PROFILE
+            ]:
+                dialog.queryEnvKey(
+                    dialog=self.dialog,
+                    logger=self.logger,
+                    env=self.environment,
+                    key=ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME,
                     name='CI_OPENSCAP_PROFILE_NAME',
                     note=_(
                         'Please provide the security profile you '
                         'would like to use (@VALUES@) [@DEFAULT@]: '
                     ),
                     prompt=True,
-                    validValues=(_('stig'), _('pci-dss')),
+                    validValues=('stig', 'pci-dss'),
                     caseSensitive=False,
                     default='stig',
                 )


### PR DESCRIPTION
Currently, we support only stig security profile.
This PR allows choosing the security profile name,
available profile names: stig, pci-dss
Requires https://github.com/oVirt/ovirt-ansible-collection/pull/411

Bug-Url: https://bugzilla.redhat.com/2029830
Signed-off-by: Asaf Rachmani <arachman@redhat.com>