### PR TITLE
openscap: Convert profile to str before .lower()

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -32,12 +32,8 @@ jobs:
     - run: automation/check-patch.sh
       # TODO: Split to separate steps?
 
-    - name: archive artifacts
-      # https://github.com/actions/upload-artifact#too-many-uploads-resulting-in-429-responses
-      run: tar czf exported-artifacts.tar.gz exported-artifacts
-
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         name: artifacts
-        path: exported-artifacts.tar.gz
+        path: exported-artifacts

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -37,3 +37,4 @@ find \
     "$PWD/tmp.repos" \
     -iname \*.rpm \
     -exec mv {} exported-artifacts/ \;
+createrepo_c exported-artifacts

--- a/src/plugins/gr-he-ansiblesetup/core/misc.py
+++ b/src/plugins/gr-he-ansiblesetup/core/misc.py
@@ -327,9 +327,9 @@ class Plugin(plugin.PluginBase):
             'he_apply_openscap_profile': self.environment[
                 ohostedcons.CloudInit.APPLY_OPENSCAP_PROFILE
             ],
-            'he_openscap_profile_name': self.environment[
+            'he_openscap_profile_name': str(self.environment[
                 ohostedcons.CloudInit.OPENSCAP_PROFILE_NAME
-            ].lower(),
+            ]).lower(),
             'he_enable_fips': self.environment[
                 ohostedcons.CloudInit.ENABLE_FIPS
             ],


### PR DESCRIPTION
It defaults to None, so fails.
We need it to default to None for queryEnvKey - if we default e.g. to an
empty string, queryEnvKey will not ask.

Change-Id: Ifcbe7bdf7119a5bd3fc870858d8366250fc559b8
Signed-off-by: Yedidyah Bar David <didi@redhat.com>