### PR TITLE
github: Do not archive artifacts

### DIFF
--- a/.github/workflows/check-patch.yml
+++ b/.github/workflows/check-patch.yml
@@ -32,12 +32,8 @@ jobs:
     - run: automation/check-patch.sh
       # TODO: Split to separate steps?
 
-    - name: archive artifacts
-      # https://github.com/actions/upload-artifact#too-many-uploads-resulting-in-429-responses
-      run: tar czf exported-artifacts.tar.gz exported-artifacts
-
     - name: Upload artifacts
       uses: actions/upload-artifact@v2
       with:
         name: artifacts
-        path: exported-artifacts.tar.gz
+        path: exported-artifacts


### PR DESCRIPTION
CI expects rpms to be directly inside the zip, not in a tar.gz inside
it.

Change-Id: Ifa4fab00481692d40b87e03cb80279a45412270a
Signed-off-by: Yedidyah Bar David <didi@redhat.com>