### PR TITLE
spec: Add conflict with ansible-core

### DIFF
--- a/ovirt-hosted-engine-setup.spec.in
+++ b/ovirt-hosted-engine-setup.spec.in
@@ -71,6 +71,8 @@ Requires:       virt-install
 # The whole way of consuming anisble roles is going to change
 # skipping ansible dependencies until we have something working.
 Requires:       ansible >= 2.9.21, ansible < 2.10.0
+# Conflicts ansible-core >= 2.10 since it provides ansible
+Conflicts:      ansible-core >= 2.10.0
 Requires:       ovirt-ansible-collection >= 1.6.7
 %endif
 # default libvirt network


### PR DESCRIPTION
Add conflict with ansible-core >= 2.10 since it provides ansible

Signed-off-by: Asaf Rachmani <arachman@redhat.com>