### PR TITLE
ansible: Fix deprecation warning added in 2.11

### DIFF
--- a/src/ovirt_hosted_engine_setup/ansible_utils.py
+++ b/src/ovirt_hosted_engine_setup/ansible_utils.py
@@ -156,7 +156,7 @@ class AnsibleHelper(base.Base):
         env = os.environ.copy()
         env[ohostedcons.AnsibleCallback.OTOPI_CALLBACK_OF] = out_path
         env[
-            'ANSIBLE_CALLBACK_WHITELIST'
+            'ANSIBLE_CALLBACKS_ENABLED'
         ] = '{com},{log}'.format(
             com=ohostedcons.AnsibleCallback.CALLBACK_NAME,
             log=ohostedcons.AnsibleCallback.LOGGER_CALLBACK_NAME,


### PR DESCRIPTION
ANSIBLE_CALLBACK_WHITELIST option is deprecated in 2.15,
and replaced by ANSIBLE_CALLBACKS_ENABLED.

Bug-Url: https://bugzilla.redhat.com/2052686
Signed-off-by: Asaf Rachmani <arachman@redhat.com>