### PR TITLE
Revert "Setup: Require --6 or --4 (#17)"

### DIFF
--- a/src/bin/hosted-engine.in
+++ b/src/bin/hosted-engine.in
@@ -148,9 +148,9 @@ Usage: $0 --deploy [args]
     --restore-from-file=<file>
         Restore an engine backup file during the deployment.
     --4
-        Run the deployment using IPv4.
+        Force IPv4 on dual stack env.
     --6
-        Run the deployment using IPv6.
+        Force IPv6 on dual stack env.
     --ansible-extra-vars=DATA
         Pass '--extra-vars=DATA' to all ansible calls.
         DATA can be anything that ansible can accept - var=value,
@@ -163,13 +163,7 @@ Usage: $0 --deploy [args]
 __EOF__
 return ;}
 
-    if [[ "$@" == *--4* && "$@" == *--6* ]] ; then
-        echo "--6 and --4 options cannot be specified together"
-    elif [[ "$@" == *--4* || "$@" == *--6* ]] ; then
-        exec @datadir@/ovirt-hosted-engine-setup/scripts/ovirt-hosted-engine-setup "$@"
-    else
-        echo "--6 or --4 option must be specified when using 'hosted-engine --deploy'"
-    fi
+    exec @datadir@/ovirt-hosted-engine-setup/scripts/ovirt-hosted-engine-setup "$@"
 }
 
 cmd_vm_start() {

--- a/src/bin/ovirt-hosted-engine-setup
+++ b/src/bin/ovirt-hosted-engine-setup
@@ -34,9 +34,9 @@ Usage: $0
 	--restore-from-file=file
 		Restore an engine backup file during the deployment
 	--4
-		Run the deployment using IPv4.
+		Force IPv4 on dual stack env
 	--6
-		Run the deployment using IPv6.
+		Force IPv6 on dual stack env
 	--ansible-extra-vars=DATA
 		Pass '--extra-vars=DATA' to all ansible calls.
 		DATA can be anything that ansible can accept - var=value,


### PR DESCRIPTION
This reverts commit 45c4dc37fd5fa38cc3ab2ff4f89ba360df055609.

We do not need another option to select, there already are he_force_ip4
and he_force_ip6 options that can be used. But even the default
behavior is following OS's defaults in dual-stack - IPv6 is selected
in that case.
Also note that we fully support single stack only.
