### PR TITLE
Configure keycloak

### DIFF
--- a/src/ovirt_hosted_engine_setup/constants.py
+++ b/src/ovirt_hosted_engine_setup/constants.py
@@ -430,6 +430,12 @@ class CoreEnv(object):
     MISC_REACHED = 'OVEHOSTED_CORE/miscReached'
     ANSIBLE_USER_EXTRA_VARS = 'OVEHOSTED_CORE/ansibleUserExtraVars'
 
+    @ohostedattrs(
+        answerfile=True,
+    )
+    def ENABLE_KEYCLOAK(self):
+        return 'OVEHOSTED_CORE/enableKeycloak'
+
 
 @util.export
 @util.codegen

--- a/src/plugins/gr-he-ansiblesetup/core/misc.py
+++ b/src/plugins/gr-he-ansiblesetup/core/misc.py
@@ -459,6 +459,13 @@ class Plugin(plugin.PluginBase):
         except KeyError:
             raise RuntimeError(_('Unable to get appliance disk size'))
 
+        if 'otopi_he_admin_username' in r:
+            self.environment[
+                ohostedcons.EngineEnv.ADMIN_USERNAME
+            ] = r[
+                'otopi_he_admin_username'
+            ]['ansible_facts']['he_admin_username']
+
         # TODO: get the CPU models list from /ovirt-engine/api/clusterlevels
         # once wrapped by ansible facts and filter it by host CPU architecture
         # in order to let the user choose the cluster CPU type in advance

--- a/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
+++ b/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
@@ -209,6 +209,9 @@ class Plugin(plugin.PluginBase):
             'he_admin_password': self.environment[
                 ohostedcons.EngineEnv.ADMIN_PASSWORD
             ],
+            'he_admin_username': self.environment[
+                ohostedcons.EngineEnv.ADMIN_USERNAME
+            ],
             'he_iscsi_discover_username': discover_username,
             'he_iscsi_discover_password': discover_password,
             'he_iscsi_portal_addr': portal,
@@ -320,6 +323,9 @@ class Plugin(plugin.PluginBase):
             'he_admin_password': self.environment[
                 ohostedcons.EngineEnv.ADMIN_PASSWORD
             ],
+            'he_admin_username': self.environment[
+                ohostedcons.EngineEnv.ADMIN_USERNAME
+            ],
             'he_iscsi_username': username,
             'he_iscsi_password': password,
             'he_iscsi_portal_addr': portal,
@@ -374,7 +380,10 @@ class Plugin(plugin.PluginBase):
             ],
             'he_admin_password': self.environment[
                 ohostedcons.EngineEnv.ADMIN_PASSWORD
-            ]
+            ],
+            'he_admin_username': self.environment[
+                ohostedcons.EngineEnv.ADMIN_USERNAME
+            ],
         }
         ansible_helper = ansible_utils.AnsibleHelper(
             tags=ohostedcons.Const.HE_TAG_FC_GETDEVICES,
@@ -774,6 +783,9 @@ class Plugin(plugin.PluginBase):
                 ],
                 'he_admin_password': self.environment[
                     ohostedcons.EngineEnv.ADMIN_PASSWORD
+                ],
+                'he_admin_username': self.environment[
+                    ohostedcons.EngineEnv.ADMIN_USERNAME
                 ],
                 'he_local_vm_dir': self.environment[
                     ohostedcons.CoreEnv.LOCAL_VM_DIR

--- a/src/plugins/gr-he-ansiblesetup/core/target_vm.py
+++ b/src/plugins/gr-he-ansiblesetup/core/target_vm.py
@@ -106,6 +106,9 @@ class Plugin(plugin.PluginBase):
             'he_admin_password': self.environment[
                 ohostedcons.EngineEnv.ADMIN_PASSWORD
             ],
+            'he_admin_username': self.environment[
+                ohostedcons.EngineEnv.ADMIN_USERNAME
+            ],
             'he_appliance_password': self.environment[
                 ohostedcons.CloudInit.ROOTPWD
             ],


### PR DESCRIPTION
Allow configuring keycloak on the engine.

- Prompt the user, asking whether to configure keycloak
- Pass the answer to ansible code
- Get the engine admin username from ansible code, if passed
- Pass this on to next calls to ansible

Please note that whether this actually causes `engine-setup` to configure keycloak depends on availability and functionality of relevant code.
Right now this code is not included by default. This patch is in preparation for changing this.