### PR TITLE
test, do not merge: Log ansible-playbook also to stderr

### DIFF
--- a/src/he_ansible/callback_plugins/1_otopi_json.py
+++ b/src/he_ansible/callback_plugins/1_otopi_json.py
@@ -84,6 +84,7 @@ class CallbackModule(CallbackBase):
                 )
         else:
             self._display.display(str(body))
+        sys.stderr.write(str(body)+'\n')
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         level = 'fatal'


### PR DESCRIPTION
Trying to understand what outputs 'The loop variable 'item' is already
in use' to stderr without context.

Change-Id: I1c66881f1461d8d3ada96b810fb5a1aabf31859f
Signed-off-by: Yedidyah Bar David <didi@redhat.com>