### PR TITLE
packaging: Use /usr/libexec for ovirt-hosted-engine-ha binaries

### DIFF
--- a/src/bin/hosted-engine.in
+++ b/src/bin/hosted-engine.in
@@ -544,7 +544,7 @@ return ;}
 
     if [ -n "${vmid}" ] ; then
         check_vm_conf
-        exec @datadir@/ovirt-hosted-engine-ha/ovirt-ha-agent --cleanup "$@"
+        exec /usr/libexec/ovirt-hosted-engine-ha/ovirt-ha-agent --cleanup "$@"
     else
         exit_not_deployed
     fi


### PR DESCRIPTION
The hosted-engine-ha binaries moved from /usr/share to /usr/libexec
see also: https://github.com/oVirt/ovirt-hosted-engine-ha/pull/7

Bug-Url: https://bugzilla.redhat.com/2105781
Signed-off-by: Asaf Rachmani <arachman@redhat.com>