### PR TITLE
build: Add '-y' to dnf

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -13,7 +13,7 @@ autoreconf -ivf
 make dist
 
 if [ -x /usr/bin/dnf ] ; then
-    dnf builddep ovirt-hosted-engine-setup.spec
+    dnf builddep -y ovirt-hosted-engine-setup.spec
 else
     yum-builddep ovirt-hosted-engine-setup.spec
 fi


### PR DESCRIPTION
build fails due to dnf execution being interactive.
Add '-y' to dnf when installing build dependencies.

Signed-off-by: Asaf Rachmani <arachman@redhat.com>