### PR TITLE
Fix ansible-core dependency

### DIFF
--- a/ovirt-hosted-engine-setup.spec.in
+++ b/ovirt-hosted-engine-setup.spec.in
@@ -71,8 +71,14 @@ Requires:       sanlock >= 2.8
 Requires:       sudo
 Requires:       libvirt-client >= 6.6.0-9
 Requires:       virt-install
+
 Requires:       ansible-core >= 2.12
+# ansible-core 2.13 uses Python 3.9, and many modules are missing a Python 3.9
+# build on el8. TODO: Provide them? Instead of or in addition to Python 3.8?
+%if 0%{?rhel} < 9
 Conflicts:      ansible-core >= 2.13
+%endif
+
 Requires:       ovirt-ansible-collection >= 2.0.0
 # default libvirt network
 Requires:       libvirt-daemon-config-network


### PR DESCRIPTION
On EL8 we depends on ansible-core 2.12, which is using non-standard
Python version 3.8, but we have already rebuilt all our dependencies for
it so we are fine. But without additional effort around dependencies
rebuild we cannot upgrade to ansible-core 2.13, because it bumped
Python requirement to 3.9.

On EL9 we can use both ansible-core 2.12 and 2.13, because both of them
are using platform python, which is 3.9, so we have all required
dependencies available.

Signed-off-by: Martin Perina <mperina@redhat.com>
