### PR TITLE
Fix deprecated import

### DIFF
--- a/src/he_ansible/callback_plugins/2_ovirt_logger.py
+++ b/src/he_ansible/callback_plugins/2_ovirt_logger.py
@@ -31,8 +31,8 @@ import pprint
 import re
 
 
-from collections import Callable
 from collections import defaultdict
+from collections.abc import Callable
 from datetime import datetime
 
 from ansible.plugins.callback import CallbackBase


### PR DESCRIPTION
This import has been deprecated in py3.3 and doesn't work since py3.10.

Signed-off-by: Marcin Sobczyk <msobczyk@redhat.com>
