### PR TITLE
add python3-importlib-resources dependency

### DIFF
--- a/ovirt-hosted-engine-setup.spec.in
+++ b/ovirt-hosted-engine-setup.spec.in
@@ -53,6 +53,7 @@ Requires:       %{python_target_version}-sanlock
 Requires:       %{python_target_version}-libselinux
 
 Requires:       %{python_target_version}-distro
+Requires:       %{python_target_version}-importlib-resources
 Requires:       %{python_target_version}-netaddr
 Requires:       %{python_target_version}-otopi >= 1.9.0
 Requires:       %{python_target_version}-ovirt-setup-lib >= 1.3.3


### PR DESCRIPTION
needed for python3-netaddr on Python 3.6 but it's undeclared there so we have to explicitly require it