### PR TITLE
require python3-importlib-resources only on el8

### DIFF
--- a/ovirt-hosted-engine-setup.spec.in
+++ b/ovirt-hosted-engine-setup.spec.in
@@ -53,7 +53,10 @@ Requires:       %{python_target_version}-sanlock
 Requires:       %{python_target_version}-libselinux
 
 Requires:       %{python_target_version}-distro
+%if 0%{?rhel} < 9
+# undeclared dependency of netaddr in python 3.6 only
 Requires:       %{python_target_version}-importlib-resources
+%endif
 Requires:       %{python_target_version}-netaddr
 Requires:       %{python_target_version}-otopi >= 1.9.0
 Requires:       %{python_target_version}-ovirt-setup-lib >= 1.3.3


### PR DESCRIPTION
it's only required for python 3.6 that's used only on el8