### PR TITLE
Add sshpass as a dependency for EL10+

### DIFF
--- a/ovirt-hosted-engine-setup.spec.in
+++ b/ovirt-hosted-engine-setup.spec.in
@@ -87,6 +87,8 @@ Requires:       vdsm-python >= 4.50
 Requires(post): vdsm-python >= 4.50
 Requires:       ovirt-host >= 4.5.0
 
+Requires:       sshpass
+
 Conflicts:      ovirt-engine-appliance < 4.5
 Conflicts:      ovirt-engine-appliance >= 4.6
 


### PR DESCRIPTION
```
[ ERROR ] fatal: [localhost]: FAILED! => {"msg": "to use the 'ssh' connection type with passwords or pkcs11_provider, you must install the sshpass program"}
```
sshpass is no longer installed by default on e.g. CentOS 10 so we need to make sure it is installed

Also see:
- https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/10.1_release_notes/known-issues
- https://sshpass.com/why-is-sshpass-not-installed-by-default-in-many-linux-distributions/