### PR TITLE
core: pass he_admin_username to subsequent ansible-playbook invocation

### DIFF
--- a/src/plugins/gr-he-ansiblesetup/core/misc.py
+++ b/src/plugins/gr-he-ansiblesetup/core/misc.py
@@ -359,6 +359,9 @@ class Plugin(plugin.PluginBase):
             'he_admin_password': self.environment[
                 ohostedcons.EngineEnv.ADMIN_PASSWORD
             ],
+            'he_admin_username': self.environment[
+                ohostedcons.EngineEnv.ADMIN_USERNAME
+            ],
             'he_appliance_password': self.environment[
                 ohostedcons.CloudInit.ROOTPWD
             ],


### PR DESCRIPTION
The Set admin username task in 04_engine_final_tasks.yml correctly populates he_admin_username, and misc.py reads the value back into the otopi environment as ohostedcons.EngineEnv.ADMIN_USERNAME. However, the value is not added to the extra_vars dict used for the next ansible-playbook invocation, so auth_sso.yml runs with he_admin_username undefined and the SDK call fails with:

  Cannot authenticate user 'None@N/A':
  No valid profile found in credentials.

Add he_admin_username to the extra_vars dict next to the existing he_admin_password entry, mirroring the existing pattern.

Fixes: ovirt-engine issue 1141