### PR TITLE
Feature/nvme overtcp

### DIFF
--- a/src/ovirt_hosted_engine_setup/constants.py
+++ b/src/ovirt_hosted_engine_setup/constants.py
@@ -20,7 +20,6 @@
 
 """Constants."""
 
-
 import gettext
 import os
 import sys
@@ -31,13 +30,11 @@ from ovirt_hosted_engine_setup import config
 
 
 def _(m):
-    return gettext.dgettext(message=m, domain='ovirt-hosted-engine-setup')
+    return gettext.dgettext(message=m, domain="ovirt-hosted-engine-setup")
 
 
 def ohostedattrsclass(o):
-    sys.modules[o.__module__].__dict__.setdefault(
-        '__hosted_attrs__', []
-    ).append(o)
+    sys.modules[o.__module__].__dict__.setdefault("__hosted_attrs__", []).append(o)
     return o
 
 
@@ -59,36 +56,38 @@ def ohostedattrs(
                 summary=summary,
                 description=description,
             )
+
     return decorator
 
 
 @util.export
 @util.codegen
 class FileSystemTypes(object):
-    NFS = 'nfs'
-    GLUSTERFS = 'glusterfs'
+    NFS = "nfs"
+    GLUSTERFS = "glusterfs"
 
 
 @util.export
 @util.codegen
 class DomainTypes(object):
-    NFS = 'nfs'
-    NFS3 = 'nfs3'
-    NFS4 = 'nfs4'
-    GLUSTERFS = 'glusterfs'
-    ISCSI = 'iscsi'
-    FC = 'fc'
+    NFS = "nfs"
+    NFS3 = "nfs3"
+    NFS4 = "nfs4"
+    GLUSTERFS = "glusterfs"
+    ISCSI = "iscsi"
+    FC = "fc"
+    NVMEOF = "nvmeof"
 
 
 @util.export
 @util.codegen
 class NfsVersions(object):
-    AUTO = 'auto'
-    V3 = 'v3'
-    V4 = 'v4'
-    V4_0 = 'v4_0'
-    V4_1 = 'v4_1'
-    V4_2 = 'v4_2'
+    AUTO = "auto"
+    V3 = "v3"
+    V4 = "v4"
+    V4_0 = "v4_0"
+    V4_1 = "v4_1"
+    V4_2 = "v4_2"
 
 
 @util.export
@@ -121,210 +120,125 @@ class VDSMConstants(object):
 @util.export
 @util.codegen
 class StorageDomainType(object):
-    UNKNOWN = 'UNKNOWN'
-    NFS = 'NFS'
-    FCP = 'FCP'
-    ISCSI = 'ISCSI'
-    LOCALFS = 'LOCALFS'
-    CIFS = 'CIFS'
-    SHAREDFS = 'SHAREDFS'
-    GLUSTERFS = 'GLUSTERFS'
+    UNKNOWN = "UNKNOWN"
+    NFS = "NFS"
+    FCP = "FCP"
+    ISCSI = "ISCSI"
+    LOCALFS = "LOCALFS"
+    CIFS = "CIFS"
+    SHAREDFS = "SHAREDFS"
+    GLUSTERFS = "GLUSTERFS"
 
 
 @util.export
 @util.codegen
 class FileLocations(object):
-    SYSCONFDIR = '/etc'
-    DATADIR = '/usr/share'
+    SYSCONFDIR = "/etc"
+    DATADIR = "/usr/share"
     DOCDIR = config.DOCDIR
-    LIBEXECDIR = '/usr/libexec'
-    SD_MOUNT_PARENT_DIR = '/rhev/data-center/mnt'
-    LOCALTIME = '/etc/localtime'
-    TZ_PARENT_DIR = '/usr/share/zoneinfo'
-    OVIRT_HOSTED_ENGINE = 'ovirt-hosted-engine'
-    OVIRT_HOSTED_ENGINE_HA = 'ovirt-hosted-engine-ha'
-    OVIRT_HOSTED_ENGINE_SETUP = 'ovirt-hosted-engine-setup'
+    LIBEXECDIR = "/usr/libexec"
+    SD_MOUNT_PARENT_DIR = "/rhev/data-center/mnt"
+    LOCALTIME = "/etc/localtime"
+    TZ_PARENT_DIR = "/usr/share/zoneinfo"
+    OVIRT_HOSTED_ENGINE = "ovirt-hosted-engine"
+    OVIRT_HOSTED_ENGINE_HA = "ovirt-hosted-engine-ha"
+    OVIRT_HOSTED_ENGINE_SETUP = "ovirt-hosted-engine-setup"
     OVIRT_HOSTED_ENGINE_SETUP_LOGDIR = os.path.join(
         config.LOCALSTATEDIR,
-        'log',
+        "log",
         OVIRT_HOSTED_ENGINE_SETUP,
     )
 
     OVIRT_HOSTED_ENGINE_SETUP_CONFIG_FILE = os.path.join(
         config.SYSCONFDIR,
-        '%s.conf' % OVIRT_HOSTED_ENGINE_SETUP,
+        "%s.conf" % OVIRT_HOSTED_ENGINE_SETUP,
     )
 
     ENGINE_VM_TEMPLATE = os.path.join(
-        config.DATADIR,
-        OVIRT_HOSTED_ENGINE_SETUP,
-        'templates',
-        'vm.conf.in'
+        config.DATADIR, OVIRT_HOSTED_ENGINE_SETUP, "templates", "vm.conf.in"
     )
     ENGINE_VM_CONF = os.path.join(
-        config.LOCALSTATEDIR,
-        'run',
-        OVIRT_HOSTED_ENGINE_HA,
-        'vm.conf'
+        config.LOCALSTATEDIR, "run", OVIRT_HOSTED_ENGINE_HA, "vm.conf"
     )
     # TODO: Only for upgrades, remove after 3.6
     PREV_ENGINE_VM_CONF = os.path.join(
-        config.SYSCONFDIR,
-        OVIRT_HOSTED_ENGINE,
-        'vm.conf'
+        config.SYSCONFDIR, OVIRT_HOSTED_ENGINE, "vm.conf"
     )
     OVIRT_APPLIANCES_DESC_DIR = os.path.join(
         config.SYSCONFDIR,
         OVIRT_HOSTED_ENGINE,
     )
-    OVIRT_APPLIANCES_DESC_FILENAME_TEMPLATE = '*-appliance.conf'
+    OVIRT_APPLIANCES_DESC_FILENAME_TEMPLATE = "*-appliance.conf"
     OVIRT_HOSTED_ENGINE_TEMPLATE = os.path.join(
-        config.DATADIR,
-        OVIRT_HOSTED_ENGINE_SETUP,
-        'templates',
-        'hosted-engine.conf.in'
+        config.DATADIR, OVIRT_HOSTED_ENGINE_SETUP, "templates", "hosted-engine.conf.in"
     )
     OVIRT_HOSTED_ENGINE_SETUP_CONF = os.path.join(
-        config.SYSCONFDIR,
-        OVIRT_HOSTED_ENGINE,
-        'hosted-engine.conf'
+        config.SYSCONFDIR, OVIRT_HOSTED_ENGINE, "hosted-engine.conf"
     )
     OVIRT_HOSTED_ENGINE_ANSWERS = os.path.join(
-        config.SYSCONFDIR,
-        OVIRT_HOSTED_ENGINE,
-        'answers.conf'
+        config.SYSCONFDIR, OVIRT_HOSTED_ENGINE, "answers.conf"
     )
     OVIRT_HOSTED_ENGINE_LB_DIR = os.path.join(
         config.LOCALSTATEDIR,
-        'lib',
+        "lib",
         OVIRT_HOSTED_ENGINE_SETUP,
     )
     OVIRT_HOSTED_ENGINE_ANSWERS_ARCHIVE_DIR = os.path.join(
-        config.LOCALSTATEDIR,
-        'lib',
-        OVIRT_HOSTED_ENGINE_SETUP,
-        'answers'
+        config.LOCALSTATEDIR, "lib", OVIRT_HOSTED_ENGINE_SETUP, "answers"
     )
     HOSTED_ENGINE_IPTABLES_TEMPLATE = os.path.join(
-        config.DATADIR,
-        OVIRT_HOSTED_ENGINE_SETUP,
-        'templates',
-        'iptables.default.in'
+        config.DATADIR, OVIRT_HOSTED_ENGINE_SETUP, "templates", "iptables.default.in"
     )
     HOSTED_ENGINE_IPTABLES_EXAMPLE = os.path.join(
-        config.SYSCONFDIR,
-        OVIRT_HOSTED_ENGINE,
-        'iptables.example'
+        config.SYSCONFDIR, OVIRT_HOSTED_ENGINE, "iptables.example"
     )
     HOSTED_ENGINE_FIREWALLD_EXAMPLE_DIR = os.path.join(
-        config.SYSCONFDIR,
-        OVIRT_HOSTED_ENGINE,
-        'firewalld'
+        config.SYSCONFDIR, OVIRT_HOSTED_ENGINE, "firewalld"
     )
     HOSTED_ENGINE_FIREWALLD_TEMPLATES_DIR = os.path.join(
         config.DATADIR,
         OVIRT_HOSTED_ENGINE_SETUP,
-        'templates',
-        'firewalld',
+        "templates",
+        "firewalld",
     )
 
-    VDSM_GEN_CERTS = os.path.join(
-        LIBEXECDIR,
-        'vdsm',
-        'vdsm-gencerts.sh'
-    )
-    VDSM_CA_CERT = os.path.join(
-        SYSCONFDIR,
-        'pki',
-        'vdsm',
-        'certs',
-        'cacert.pem'
-    )
-    SYS_CA_CERT = os.path.join(
-        SYSCONFDIR,
-        'pki',
-        'CA',
-        'cacert.pem'
-    )
-    SYS_CUSTOMCA_CERT = os.path.join(
-        SYSCONFDIR,
-        'pki',
-        'CA',
-        'ovirtcustomcacert.pem'
-    )
-    VDSMCERT = os.path.join(
-        SYSCONFDIR,
-        'pki',
-        'vdsm',
-        'certs',
-        'vdsmcert.pem'
-    )
-    VDSMKEY = os.path.join(
-        SYSCONFDIR,
-        'pki',
-        'vdsm',
-        'keys',
-        'vdsmkey.pem'
-    )
-    VDSM_CONF = os.path.join(
-        SYSCONFDIR,
-        'vdsm',
-        'vdsm.conf'
-    )
-    LIBVIRT_PKI = os.path.join(
-        SYSCONFDIR,
-        'pki',
-        'libvirt'
-    )
+    VDSM_GEN_CERTS = os.path.join(LIBEXECDIR, "vdsm", "vdsm-gencerts.sh")
+    VDSM_CA_CERT = os.path.join(SYSCONFDIR, "pki", "vdsm", "certs", "cacert.pem")
+    SYS_CA_CERT = os.path.join(SYSCONFDIR, "pki", "CA", "cacert.pem")
+    SYS_CUSTOMCA_CERT = os.path.join(SYSCONFDIR, "pki", "CA", "ovirtcustomcacert.pem")
+    VDSMCERT = os.path.join(SYSCONFDIR, "pki", "vdsm", "certs", "vdsmcert.pem")
+    VDSMKEY = os.path.join(SYSCONFDIR, "pki", "vdsm", "keys", "vdsmkey.pem")
+    VDSM_CONF = os.path.join(SYSCONFDIR, "vdsm", "vdsm.conf")
+    LIBVIRT_PKI = os.path.join(SYSCONFDIR, "pki", "libvirt")
     LIBVIRT_PKI_PRIVATE = os.path.join(
         LIBVIRT_PKI,
-        'private',
+        "private",
     )
-    LIBVIRT_CLIENT_CERT = os.path.join(
-        LIBVIRT_PKI,
-        'clientcert.pem'
-    )
-    LIBVIRT_CLIENT_KEY = os.path.join(
-        LIBVIRT_PKI_PRIVATE,
-        'clientkey.pem'
-    )
-    LIBVIRT_SERVER_CERT = os.path.join(
-        LIBVIRT_PKI,
-        'servercert.pem'
-    )
-    LIBVIRT_SERVER_KEY = os.path.join(
-        LIBVIRT_PKI_PRIVATE,
-        'serverkey.pem'
-    )
-    LIBVIRT_QEMU_CONF = os.path.join(
-        SYSCONFDIR,
-        'libvirt',
-        'qemu.conf'
-    )
-    ENGINE_HA_CONFDIR = os.path.join(
-        SYSCONFDIR,
-        OVIRT_HOSTED_ENGINE_HA
-    )
+    LIBVIRT_CLIENT_CERT = os.path.join(LIBVIRT_PKI, "clientcert.pem")
+    LIBVIRT_CLIENT_KEY = os.path.join(LIBVIRT_PKI_PRIVATE, "clientkey.pem")
+    LIBVIRT_SERVER_CERT = os.path.join(LIBVIRT_PKI, "servercert.pem")
+    LIBVIRT_SERVER_KEY = os.path.join(LIBVIRT_PKI_PRIVATE, "serverkey.pem")
+    LIBVIRT_QEMU_CONF = os.path.join(SYSCONFDIR, "libvirt", "qemu.conf")
+    ENGINE_HA_CONFDIR = os.path.join(SYSCONFDIR, OVIRT_HOSTED_ENGINE_HA)
     NOTIFY_CONF_FILE = os.path.join(  # TODO: Upgrades only, remove after 3.6
-        ENGINE_HA_CONFDIR,
-        'broker.conf'
+        ENGINE_HA_CONFDIR, "broker.conf"
     )
-    HECONFD_VERSION = 'version'
-    HECONFD_ANSWERFILE = 'fhanswers.conf'
-    HECONFD_HECONF = 'hosted-engine.conf'
-    HECONFD_BROKER_CONF = 'broker.conf'
-    HECONFD_VM_CONF = 'vm.conf'
+    HECONFD_VERSION = "version"
+    HECONFD_ANSWERFILE = "fhanswers.conf"
+    HECONFD_HECONF = "hosted-engine.conf"
+    HECONFD_BROKER_CONF = "broker.conf"
+    HECONFD_VM_CONF = "vm.conf"
 
-    LOCAL_VM_DIR_PATH = '/var/tmp'
-    LOCAL_VM_DIR_PREFIX = 'localvm'
+    LOCAL_VM_DIR_PATH = "/var/tmp"
+    LOCAL_VM_DIR_PREFIX = "localvm"
 
     HOSTED_ENGINE_ANSIBLE_PATH = os.path.join(
         config.DATADIR,
         OVIRT_HOSTED_ENGINE_SETUP,
-        'he_ansible',
+        "he_ansible",
     )
 
-    HE_AP_TRIGGER_ROLE = 'trigger_role.yml'
+    HE_AP_TRIGGER_ROLE = "trigger_role.yml"
 
 
 @util.export
@@ -332,10 +246,10 @@ class FileLocations(object):
 class Const(object):
     MINIMUM_SPACE_STORAGEDOMAIN_MB = 20480
     FIRST_HOST_ID = 1
-    HA_AGENT_SERVICE = 'ovirt-ha-agent'
-    HA_BROCKER_SERVICE = 'ovirt-ha-broker'
-    HOSTED_ENGINE_VM_NAME = 'HostedEngine'
-    CONF_IMAGE_DESC = 'HostedEngineConfigurationImage'
+    HA_AGENT_SERVICE = "ovirt-ha-agent"
+    HA_BROCKER_SERVICE = "ovirt-ha-broker"
+    HOSTED_ENGINE_VM_NAME = "HostedEngine"
+    CONF_IMAGE_DESC = "HostedEngineConfigurationImage"
     # On block devices the VM image should be preallocated into the VG
     # The VG by itself introduces some overhead that we need to take care of
     # verifying  the image size before creating them
@@ -347,233 +261,234 @@ class Const(object):
     CRITICAL_SPACE_ACTION_BLOCKER = 5
     METADATA_CHUNK_SIZE = 4096
     MAX_HOST_ID = 250
-    HA_NOTIF_SMTP_SERVER = 'smtp-server'
-    HA_NOTIF_SMTP_PORT = 'smtp-port'
-    HA_NOTIF_SMTP_SOURCE_EMAIL = 'source-email'
-    HA_NOTIF_SMTP_DEST_EMAILS = 'destination-emails'
-    BLANK_UUID = '00000000-0000-0000-0000-000000000000'
+    HA_NOTIF_SMTP_SERVER = "smtp-server"
+    HA_NOTIF_SMTP_PORT = "smtp-port"
+    HA_NOTIF_SMTP_SOURCE_EMAIL = "source-email"
+    HA_NOTIF_SMTP_DEST_EMAILS = "destination-emails"
+    BLANK_UUID = "00000000-0000-0000-0000-000000000000"
     VDSCLI_SSL_TIMEOUT = 900
-    CLOUD_INIT_GENERATE = 'generate'
-    CLOUD_INIT_SKIP = 'skip'
-    CLOUD_INIT_EXISTING = 'existing'
-    CLOUD_INIT_APPLIANCEANSWERS = '/root/ovirt-engine-answers'
-    CLOUD_INIT_HEANSWERS = '/root/heanswers.conf'
-    OVIRT_HE_CHANNEL_NAME = 'org.ovirt.hosted-engine-setup.0'
-    OVIRT_HE_CHANNEL_PATH = '/var/lib/libvirt/qemu/channels/'
-    VIRTIO_PORTS_PATH = '/dev/virtio-ports/'
-    E_SETUP_SUCCESS_STRING = 'HE_APPLIANCE_ENGINE_SETUP_SUCCESS'
-    E_SETUP_FAIL_STRING = 'HE_APPLIANCE_ENGINE_SETUP_FAIL'
-    E_RESTORE_SUCCESS_STRING = 'HE_APPLIANCE_ENGINE_RESTORE_SUCCESS'
-    E_RESTORE_FAIL_STRING = 'HE_APPLIANCE_ENGINE_RESTORE_FAIL'
+    CLOUD_INIT_GENERATE = "generate"
+    CLOUD_INIT_SKIP = "skip"
+    CLOUD_INIT_EXISTING = "existing"
+    CLOUD_INIT_APPLIANCEANSWERS = "/root/ovirt-engine-answers"
+    CLOUD_INIT_HEANSWERS = "/root/heanswers.conf"
+    OVIRT_HE_CHANNEL_NAME = "org.ovirt.hosted-engine-setup.0"
+    OVIRT_HE_CHANNEL_PATH = "/var/lib/libvirt/qemu/channels/"
+    VIRTIO_PORTS_PATH = "/dev/virtio-ports/"
+    E_SETUP_SUCCESS_STRING = "HE_APPLIANCE_ENGINE_SETUP_SUCCESS"
+    E_SETUP_FAIL_STRING = "HE_APPLIANCE_ENGINE_SETUP_FAIL"
+    E_RESTORE_SUCCESS_STRING = "HE_APPLIANCE_ENGINE_RESTORE_SUCCESS"
+    E_RESTORE_FAIL_STRING = "HE_APPLIANCE_ENGINE_RESTORE_FAIL"
     # sync with engine table storage_server_connections
     # (packaging/dbscripts/create_tables.sql)
     MAX_STORAGE_USERNAME_LENGTH = 50
     MAX_STORAGE_PASSWORD_LENGTH = 50
-    UPGRADE_SUPPORTED_SOURCES = ['3.6']
-    UPGRADE_SUPPORTED_TARGETS = ['4.0']
-    UPGRADE_REQUIRED_CLUSTER_V = ['3.6', '4.0', '4.1']
-    BACKUP_DISK_PREFIX = 'hosted-engine-backup-'
-    APPLIANCE_RPM_NAME = '%s-appliance' % config.APPLIANCE_RPM_PREFIX
-    APPLIANCE40_RPM_NAME = '%s-appliance' % config.APPLIANCE40_RPM_PREFIX
+    UPGRADE_SUPPORTED_SOURCES = ["3.6"]
+    UPGRADE_SUPPORTED_TARGETS = ["4.0"]
+    UPGRADE_REQUIRED_CLUSTER_V = ["3.6", "4.0", "4.1"]
+    BACKUP_DISK_PREFIX = "hosted-engine-backup-"
+    APPLIANCE_RPM_NAME = "%s-appliance" % config.APPLIANCE_RPM_PREFIX
+    APPLIANCE40_RPM_NAME = "%s-appliance" % config.APPLIANCE40_RPM_PREFIX
     VM_LIVELINESS_CHECK_TIMEOUT = 900
-    ANSIBLE_R_OTOPI_PREFIX = 'otopi_'
+    ANSIBLE_R_OTOPI_PREFIX = "otopi_"
     STORAGE_SERVER_TIMEOUT = 60
     HOST_RESERVED_MEMORY_MB = 512
     MAX_DIALOG_ATTEMPTS = 1000
 
-    HE_TAG_INITIAL_CLEAN = 'initial_clean'
-    HE_TAG_FINAL_CLEAN = 'final_clean'
-    HE_TAG_BOOTSTRAP_LOCAL_VM = 'bootstrap_local_vm'
-    HE_TAG_CREATE_SD = 'create_storage_domain'
-    HE_TAG_CREATE_VM = 'create_target_vm'
-    HE_TAG_ISCSI_DISCOVER = 'iscsi_discover'
-    HE_TAG_ISCSI_GETDEVICES = 'iscsi_getdevices'
-    HE_TAG_FC_GETDEVICES = 'fc_getdevices'
-    HE_TAG_NETWORK_INTERFACES = 'get_network_interfaces'
-    HE_TAG_VALIDATE_HOSTNAMES = 'validate_hostnames'
+    HE_TAG_INITIAL_CLEAN = "initial_clean"
+    HE_TAG_FINAL_CLEAN = "final_clean"
+    HE_TAG_BOOTSTRAP_LOCAL_VM = "bootstrap_local_vm"
+    HE_TAG_CREATE_SD = "create_storage_domain"
+    HE_TAG_CREATE_VM = "create_target_vm"
+    HE_TAG_ISCSI_DISCOVER = "iscsi_discover"
+    HE_TAG_ISCSI_GETDEVICES = "iscsi_getdevices"
+    HE_TAG_FC_GETDEVICES = "fc_getdevices"
+    HE_TAG_NVMEOF_DISCOVER = "nvmeof_discover"
+    HE_TAG_NVMEOF_GETDEVICES = "nvmeof_getdevices"
+    HE_TAG_NETWORK_INTERFACES = "get_network_interfaces"
+    HE_TAG_VALIDATE_HOSTNAMES = "validate_hostnames"
 
 
 @util.export
 @util.codegen
 @ohostedattrsclass
 class CoreEnv(object):
-    USER_ANSWER_FILE = 'OVEHOSTED_CORE/userAnswerFile'
-    ETC_ANSWER_FILE = 'OVEHOSTED_CORE/etcAnswerFile'
-    REQUIREMENTS_CHECK_ENABLED = 'OVEHOSTED_CORE/checkRequirements'
-    MEM_REQUIREMENTS_CHECK_ENABLED = 'OVEHOSTED_CORE/memCheckRequirements'
-    RESTORE_FROM_FILE = 'OVEHOSTED_CORE/restoreFromFile'
-    RENEW_PKI_ON_RESTORE = 'OVEHOSTED_CORE/renewPKIonRestore'
-    PAUSE_ON_RESTORE = 'OVEHOSTED_CORE/pauseonRestore'
-    TEMPDIR = 'OVEHOSTED_CORE/tempDir'
-    LOCAL_VM_DIR = 'OVEHOSTED_CORE/localVMDir'
+    USER_ANSWER_FILE = "OVEHOSTED_CORE/userAnswerFile"
+    ETC_ANSWER_FILE = "OVEHOSTED_CORE/etcAnswerFile"
+    REQUIREMENTS_CHECK_ENABLED = "OVEHOSTED_CORE/checkRequirements"
+    MEM_REQUIREMENTS_CHECK_ENABLED = "OVEHOSTED_CORE/memCheckRequirements"
+    RESTORE_FROM_FILE = "OVEHOSTED_CORE/restoreFromFile"
+    RENEW_PKI_ON_RESTORE = "OVEHOSTED_CORE/renewPKIonRestore"
+    PAUSE_ON_RESTORE = "OVEHOSTED_CORE/pauseonRestore"
+    TEMPDIR = "OVEHOSTED_CORE/tempDir"
+    LOCAL_VM_DIR = "OVEHOSTED_CORE/localVMDir"
 
     @ohostedattrs(
         answerfile=True,
     )
     def DEPLOY_PROCEED(self):
-        return 'OVEHOSTED_CORE/deployProceed'
+        return "OVEHOSTED_CORE/deployProceed"
 
     @ohostedattrs(
         answerfile=True,
     )
     def TMUX_PROCEED(self):
-        return 'OVEHOSTED_CORE/screenProceed'
+        return "OVEHOSTED_CORE/screenProceed"
 
     @ohostedattrs(
         answerfile=True,
     )
     def FORCE_IP_PROCEED(self):
-        return 'OVEHOSTED_CORE/forceIpProceed'
+        return "OVEHOSTED_CORE/forceIpProceed"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CONFIRM_SETTINGS(self):
-        return 'OVEHOSTED_CORE/confirmSettings'
+        return "OVEHOSTED_CORE/confirmSettings"
 
-    SKIP_TTY_CHECK = 'OVEHOSTED_CORE/skipTTYCheck'
-    NODE_SETUP = 'OVEHOSTED_CORE/nodeSetup'
-    MISC_REACHED = 'OVEHOSTED_CORE/miscReached'
-    ANSIBLE_USER_EXTRA_VARS = 'OVEHOSTED_CORE/ansibleUserExtraVars'
+    SKIP_TTY_CHECK = "OVEHOSTED_CORE/skipTTYCheck"
+    NODE_SETUP = "OVEHOSTED_CORE/nodeSetup"
+    MISC_REACHED = "OVEHOSTED_CORE/miscReached"
+    ANSIBLE_USER_EXTRA_VARS = "OVEHOSTED_CORE/ansibleUserExtraVars"
 
     @ohostedattrs(
         answerfile=True,
     )
     def ENABLE_KEYCLOAK(self):
-        return 'OVEHOSTED_CORE/enableKeycloak'
+        return "OVEHOSTED_CORE/enableKeycloak"
 
 
 @util.export
 @util.codegen
 @ohostedattrsclass
 class NetworkEnv(object):
-
     @ohostedattrs(
         summary=True,
-        description=_('Bridge interface'),
+        description=_("Bridge interface"),
     )
     def BRIDGE_IF(self):
-        return 'OVEHOSTED_NETWORK/bridgeIf'
+        return "OVEHOSTED_NETWORK/bridgeIf"
 
     @ohostedattrs(
         summary=True,
-        description=_('Host address'),
+        description=_("Host address"),
     )
     def HOST_NAME(self):
-        return 'OVEHOSTED_NETWORK/host_name'
+        return "OVEHOSTED_NETWORK/host_name"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Engine FQDN'),
+        description=_("Engine FQDN"),
     )
     def OVIRT_HOSTED_ENGINE_FQDN(self):
-        return 'OVEHOSTED_NETWORK/fqdn'
-    FQDN_REVERSE_VALIDATION = 'OVEHOSTED_NETWORK/fqdnReverseValidation'
+        return "OVEHOSTED_NETWORK/fqdn"
+
+    FQDN_REVERSE_VALIDATION = "OVEHOSTED_NETWORK/fqdnReverseValidation"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Bridge name'),
+        description=_("Bridge name"),
     )
     def BRIDGE_NAME(self):
-        return 'OVEHOSTED_NETWORK/bridgeName'
+        return "OVEHOSTED_NETWORK/bridgeName"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Firewall manager'),
+        description=_("Firewall manager"),
     )
     def FIREWALL_MANAGER(self):
-        return 'OVEHOSTED_NETWORK/firewallManager'
+        return "OVEHOSTED_NETWORK/firewallManager"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Gateway address'),
+        description=_("Gateway address"),
     )
     def GATEWAY(self):
-        return 'OVEHOSTED_NETWORK/gateway'
+        return "OVEHOSTED_NETWORK/gateway"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Network test'),
+        description=_("Network test"),
     )
     def NETWORK_TEST(self):
-        return 'OVEHOSTED_NETWORK/network_test'
+        return "OVEHOSTED_NETWORK/network_test"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('IP address for TCP network test'),
+        description=_("IP address for TCP network test"),
     )
     def NETWORK_TEST_TCP_ADDRESS(self):
-        return 'OVEHOSTED_NETWORK/network_test_tcp_address'
+        return "OVEHOSTED_NETWORK/network_test_tcp_address"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('TCP port for TCP network test'),
+        description=_("TCP port for TCP network test"),
     )
     def NETWORK_TEST_TCP_PORT(self):
-        return 'OVEHOSTED_NETWORK/network_test_tcp_port'
+        return "OVEHOSTED_NETWORK/network_test_tcp_port"
 
-    FIREWALLD_SERVICES = 'OVEHOSTED_NETWORK/firewalldServices'
-    FIREWALLD_SUBST = 'OVEHOSTED_NETWORK/firewalldSubst'
+    FIREWALLD_SERVICES = "OVEHOSTED_NETWORK/firewalldServices"
+    FIREWALLD_SUBST = "OVEHOSTED_NETWORK/firewalldSubst"
 
     @ohostedattrs(
         summary=True,
-        description=_('SSH daemon port'),
+        description=_("SSH daemon port"),
     )
     def SSHD_PORT(self):
-        return 'OVEHOSTED_NETWORK/sshdPort'
+        return "OVEHOSTED_NETWORK/sshdPort"
 
-    PROMPT_REQUIRED_NETWORKS = 'OVEHOSTED_NETWORK/promptRequiredNetworks'
-    REFUSE_DEPLOYING_WITH_NM = 'OVEHOSTED_NETWORK/refuseDeployingWithNM'
-    ALLOW_INVALID_BOND_MODES = 'OVEHOSTED_NETWORK/allowInvalidBondModes'
+    PROMPT_REQUIRED_NETWORKS = "OVEHOSTED_NETWORK/promptRequiredNetworks"
+    REFUSE_DEPLOYING_WITH_NM = "OVEHOSTED_NETWORK/refuseDeployingWithNM"
+    ALLOW_INVALID_BOND_MODES = "OVEHOSTED_NETWORK/allowInvalidBondModes"
 
-    FORCE_IPV4 = 'OVEHOSTED_NETWORK/forceIPv4'
-    FORCE_IPV6 = 'OVEHOSTED_NETWORK/forceIPv6'
+    FORCE_IPV4 = "OVEHOSTED_NETWORK/forceIPv4"
+    FORCE_IPV6 = "OVEHOSTED_NETWORK/forceIPv6"
 
 
 @util.export
 @util.codegen
 @ohostedattrsclass
 class EngineEnv(object):
-
-    ADMIN_PASSWORD = 'OVEHOSTED_ENGINE/adminPassword'
-    ADMIN_USERNAME = 'OVEHOSTED_ENGINE/adminUsername'
-    INTERACTIVE_ADMIN_PASSWORD = 'OVEHOSTED_ENGINE/interactiveAdminPassword'
+    ADMIN_PASSWORD = "OVEHOSTED_ENGINE/adminPassword"
+    ADMIN_USERNAME = "OVEHOSTED_ENGINE/adminUsername"
+    INTERACTIVE_ADMIN_PASSWORD = "OVEHOSTED_ENGINE/interactiveAdminPassword"
 
     @ohostedattrs(
         summary=True,
-        description=_('Host name for web application'),
+        description=_("Host name for web application"),
     )
     def APP_HOST_NAME(self):
-        return 'OVEHOSTED_ENGINE/appHostName'
+        return "OVEHOSTED_ENGINE/appHostName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def HOST_CLUSTER_NAME(self):
-        return 'OVEHOSTED_ENGINE/clusterName'
+        return "OVEHOSTED_ENGINE/clusterName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def HOST_DATACENTER_NAME(self):
-        return 'OVEHOSTED_ENGINE/datacenterName'
+        return "OVEHOSTED_ENGINE/datacenterName"
 
-    TEMPORARY_CERT_FILE = 'OVEHOSTED_ENGINE/temporaryCertificate'
-    PROMPT_NON_OPERATIONAL = 'OVEHOSTED_ENGINE/promptNonOperational'
-    ENGINE_SETUP_TIMEOUT = 'OVEHOSTED_ENGINE/engineSetupTimeout'
+    TEMPORARY_CERT_FILE = "OVEHOSTED_ENGINE/temporaryCertificate"
+    PROMPT_NON_OPERATIONAL = "OVEHOSTED_ENGINE/promptNonOperational"
+    ENGINE_SETUP_TIMEOUT = "OVEHOSTED_ENGINE/engineSetupTimeout"
 
     @ohostedattrs(
         answerfile=True,
     )
     def INSECURE_SSL(self):
-        return 'OVEHOSTED_ENGINE/insecureSSL'
+        return "OVEHOSTED_ENGINE/insecureSSL"
 
 
 @util.export
@@ -582,230 +497,236 @@ class EngineEnv(object):
 class StorageEnv(object):
     @ohostedattrs(
         summary=True,
-        description=_('Host ID'),
+        description=_("Host ID"),
     )
     def HOST_ID(self):
-        return 'OVEHOSTED_STORAGE/hostID'
+        return "OVEHOSTED_STORAGE/hostID"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Storage connection'),
+        description=_("Storage connection"),
     )
     def STORAGE_DOMAIN_CONNECTION(self):
-        return 'OVEHOSTED_STORAGE/storageDomainConnection'
+        return "OVEHOSTED_STORAGE/storageDomainConnection"
 
     @ohostedattrs(
         answerfile=True,
     )
     def STORAGE_DOMAIN_NAME(self):
-        return 'OVEHOSTED_STORAGE/storageDomainName'
+        return "OVEHOSTED_STORAGE/storageDomainName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def STORAGE_DATACENTER_NAME(self):
-        return 'OVEHOSTED_STORAGE/storageDatacenterName'
+        return "OVEHOSTED_STORAGE/storageDatacenterName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CONNECTION_UUID(self):
-        return 'OVEHOSTED_STORAGE/connectionUUID'
+        return "OVEHOSTED_STORAGE/connectionUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def SD_UUID(self):
-        return 'OVEHOSTED_STORAGE/sdUUID'
+        return "OVEHOSTED_STORAGE/sdUUID"
 
-    FAKE_MASTER_SD_UUID = 'OVEHOSTED_STORAGE/fakeMasterSdUUID'
-    FAKE_MASTER_SD_CONNECTION_UUID = 'OVEHOSTED_STORAGE/fakeMasterSdConnUUID'
+    FAKE_MASTER_SD_UUID = "OVEHOSTED_STORAGE/fakeMasterSdUUID"
+    FAKE_MASTER_SD_CONNECTION_UUID = "OVEHOSTED_STORAGE/fakeMasterSdConnUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def SP_UUID(self):
-        return 'OVEHOSTED_STORAGE/spUUID'
+        return "OVEHOSTED_STORAGE/spUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def IMG_UUID(self):
-        return 'OVEHOSTED_STORAGE/imgUUID'
+        return "OVEHOSTED_STORAGE/imgUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def VOL_UUID(self):
-        return 'OVEHOSTED_STORAGE/volUUID'
+        return "OVEHOSTED_STORAGE/volUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def VG_UUID(self):
-        return 'OVEHOSTED_STORAGE/vgUUID'
+        return "OVEHOSTED_STORAGE/vgUUID"
 
-    GUID = 'OVEHOSTED_STORAGE/GUID'
+    GUID = "OVEHOSTED_STORAGE/GUID"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Image size GB'),
+        description=_("Image size GB"),
     )
     def IMAGE_SIZE_GB(self):
-        return 'OVEHOSTED_STORAGE/imgSizeGB'
+        return "OVEHOSTED_STORAGE/imgSizeGB"
 
-    QCOW_SIZE_GB = 'OVEHOSTED_STORAGE/qcowSizeGB'
-    OVF_SIZE_GB = 'OVEHOSTED_STORAGE/ovfSizeGB'
+    QCOW_SIZE_GB = "OVEHOSTED_STORAGE/qcowSizeGB"
+    OVF_SIZE_GB = "OVEHOSTED_STORAGE/ovfSizeGB"
 
-    IMAGE_DESC = 'OVEHOSTED_STORAGE/imgDesc'
+    IMAGE_DESC = "OVEHOSTED_STORAGE/imgDesc"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Storage Domain type'),
+        description=_("Storage Domain type"),
     )
     def DOMAIN_TYPE(self):
-        return 'OVEHOSTED_STORAGE/domainType'
+        return "OVEHOSTED_STORAGE/domainType"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('NFS Version'),
+        description=_("NFS Version"),
     )
     def NFS_VERSION(self):
-        return 'OVEHOSTED_STORAGE/nfsVersion'
+        return "OVEHOSTED_STORAGE/nfsVersion"
 
     @ohostedattrs(
         answerfile=True,
     )
     def MNT_OPTIONS(self):
-        return 'OVEHOSTED_STORAGE/mntOptions'
+        return "OVEHOSTED_STORAGE/mntOptions"
 
     @ohostedattrs(
         answerfile=True,
     )
     def ENABLE_HC_GLUSTER_SERVICE(self):
-        return 'OVEHOSTED_ENGINE/enableHcGlusterService'
+        return "OVEHOSTED_ENGINE/enableHcGlusterService"
 
     @ohostedattrs(
         answerfile=True,
     )
     def ALLOW_GLUSTER_REPLICA_ONE(self):
-        return 'OVEHOSTED_ENGINE/allowGlusterReplicaOne'
+        return "OVEHOSTED_ENGINE/allowGlusterReplicaOne"
 
-    ENABLE_LIBGFAPI = 'OVEHOSTED_ENGINE/enableLibgfapi'
+    ENABLE_LIBGFAPI = "OVEHOSTED_ENGINE/enableLibgfapi"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('iSCSI Portal IP Address'),
+        description=_("iSCSI Portal IP Address"),
     )
     def ISCSI_IP_ADDR(self):
-        return 'OVEHOSTED_STORAGE/iSCSIPortalIPAddress'
+        return "OVEHOSTED_STORAGE/iSCSIPortalIPAddress"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('iSCSI Portal port'),
+        description=_("iSCSI Portal port"),
     )
     def ISCSI_PORT(self):
-        return 'OVEHOSTED_STORAGE/iSCSIPortalPort'
+        return "OVEHOSTED_STORAGE/iSCSIPortalPort"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('iSCSI Target Portal Group Tag'),
+        description=_("iSCSI Target Portal Group Tag"),
     )
     def ISCSI_PORTAL(self):
-        return 'OVEHOSTED_STORAGE/iSCSIPortal'
+        return "OVEHOSTED_STORAGE/iSCSIPortal"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('iSCSI portal login user'),
+        description=_("iSCSI portal login user"),
     )
     def ISCSI_USER(self):
-        return 'OVEHOSTED_STORAGE/iSCSIPortalUser'
+        return "OVEHOSTED_STORAGE/iSCSIPortalUser"
 
     @ohostedattrs(
         answerfile=True,
-        description=_('iSCSI discover user'),
+        description=_("iSCSI discover user"),
     )
     def ISCSI_DISCOVER_USER(self):
-        return 'OVEHOSTED_STORAGE/iSCSIDiscoverUser'
+        return "OVEHOSTED_STORAGE/iSCSIDiscoverUser"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('iSCSI Target Name'),
+        description=_("iSCSI Target Name"),
     )
     def ISCSI_TARGET(self):
-        return 'OVEHOSTED_STORAGE/iSCSITargetName'
+        return "OVEHOSTED_STORAGE/iSCSITargetName"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('LUN ID'),
+        description=_("LUN ID"),
     )
     def LUN_ID(self):
-        return 'OVEHOSTED_STORAGE/LunID'
+        return "OVEHOSTED_STORAGE/LunID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def DISCARD_SUPPORT(self):
-        return 'OVEHOSTED_STORAGE/discardSupport'
+        return "OVEHOSTED_STORAGE/discardSupport"
 
-    ISCSI_PASSWORD = 'OVEHOSTED_STORAGE/iSCSIPortalPassword'
-    ISCSI_DISCOVER_PASSWORD = 'OVEHOSTED_STORAGE/iSCSIDiscoverPassword'
+    ISCSI_PASSWORD = "OVEHOSTED_STORAGE/iSCSIPortalPassword"
+    ISCSI_DISCOVER_PASSWORD = "OVEHOSTED_STORAGE/iSCSIDiscoverPassword"
 
-    BDEVICE_SIZE_GB = 'OVEHOSTED_STORAGE/blockDeviceSizeGB'
+    NVMEOF_NQN = "OVEHOSTED_STORAGE/nvmeofNqn"
+    NVMEOF_ADDR = "OVEHOSTED_STORAGE/nvmeofAddress"
+    NVMEOF_PORT = "OVEHOSTED_STORAGE/nvmeofPort"
+    NVMEOF_HOST_NQN = "OVEHOSTED_STORAGE/nvmeofHostNqn"
+    NVMEOF_DHCHAP_KEY = "OVEHOSTED_STORAGE/nvmeofDhchapKey"
+
+    BDEVICE_SIZE_GB = "OVEHOSTED_STORAGE/blockDeviceSizeGB"
 
     @ohostedattrs(
         answerfile=True,
     )
     def METADATA_VOLUME_UUID(self):
-        return 'OVEHOSTED_STORAGE/metadataVolumeUUID'
+        return "OVEHOSTED_STORAGE/metadataVolumeUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def METADATA_IMAGE_UUID(self):
-        return 'OVEHOSTED_STORAGE/metadataImageUUID'
+        return "OVEHOSTED_STORAGE/metadataImageUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def LOCKSPACE_VOLUME_UUID(self):
-        return 'OVEHOSTED_STORAGE/lockspaceVolumeUUID'
+        return "OVEHOSTED_STORAGE/lockspaceVolumeUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def LOCKSPACE_IMAGE_UUID(self):
-        return 'OVEHOSTED_STORAGE/lockspaceImageUUID'
+        return "OVEHOSTED_STORAGE/lockspaceImageUUID"
 
-    FORCE_CREATEVG = 'OVEHOSTED_ENGINE/forceCreateVG'
+    FORCE_CREATEVG = "OVEHOSTED_ENGINE/forceCreateVG"
 
-    ANSWERFILE_CONTENT = 'OVEHOSTED_STORAGE/storageAnswerFileContent'
-    HECONF_CONTENT = 'OVEHOSTED_STORAGE/storageHEConfContent'
-    BROKER_CONF_CONTENT = 'OVEHOSTED_STORAGE/brokerConfContent'
-    VM_CONF_CONTENT = 'OVEHOSTED_STORAGE/vmConfContent'
-    CONF_IMAGE_SIZE_GB = 'OVEHOSTED_STORAGE/confImageSizeGB'
+    ANSWERFILE_CONTENT = "OVEHOSTED_STORAGE/storageAnswerFileContent"
+    HECONF_CONTENT = "OVEHOSTED_STORAGE/storageHEConfContent"
+    BROKER_CONF_CONTENT = "OVEHOSTED_STORAGE/brokerConfContent"
+    VM_CONF_CONTENT = "OVEHOSTED_STORAGE/vmConfContent"
+    CONF_IMAGE_SIZE_GB = "OVEHOSTED_STORAGE/confImageSizeGB"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CONF_IMG_UUID(self):
-        return 'OVEHOSTED_STORAGE/confImageUUID'
+        return "OVEHOSTED_STORAGE/confImageUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CONF_VOL_UUID(self):
-        return 'OVEHOSTED_STORAGE/confVolUUID'
+        return "OVEHOSTED_STORAGE/confVolUUID"
 
 
 @util.export
@@ -816,108 +737,108 @@ class VMEnv(object):
         answerfile=True,
     )
     def VM_UUID(self):
-        return 'OVEHOSTED_VM/vmUUID'
+        return "OVEHOSTED_VM/vmUUID"
 
-    LOCAL_VM_UUID = 'OVEHOSTED_VM/localVmUUID'
+    LOCAL_VM_UUID = "OVEHOSTED_VM/localVmUUID"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Memory size MB'),
+        description=_("Memory size MB"),
     )
     def MEM_SIZE_MB(self):
-        return 'OVEHOSTED_VM/vmMemSizeMB'
+        return "OVEHOSTED_VM/vmMemSizeMB"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Number of CPUs'),
+        description=_("Number of CPUs"),
     )
     def VCPUS(self):
-        return 'OVEHOSTED_VM/vmVCpus'
+        return "OVEHOSTED_VM/vmVCpus"
 
-    MAXVCPUS = 'OVEHOSTED_VM/maxVCpus'
+    MAXVCPUS = "OVEHOSTED_VM/maxVCpus"
 
-    APPLIANCEVCPUS = 'OVEHOSTED_VM/applianceVCpus'
+    APPLIANCEVCPUS = "OVEHOSTED_VM/applianceVCpus"
 
-    APPLIANCEMEM = 'OVEHOSTED_VM/applianceMem'
+    APPLIANCEMEM = "OVEHOSTED_VM/applianceMem"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('MAC address'),
+        description=_("MAC address"),
     )
     def MAC_ADDR(self):
-        return 'OVEHOSTED_VM/vmMACAddr'
+        return "OVEHOSTED_VM/vmMACAddr"
 
     @ohostedattrs(
         answerfile=True,
     )
     def NIC_UUID(self):
-        return 'OVEHOSTED_VM/nicUUID'
+        return "OVEHOSTED_VM/nicUUID"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('ISO image (cdrom cloud-init)'),
+        description=_("ISO image (cdrom cloud-init)"),
     )
     def CDROM(self):
-        return 'OVEHOSTED_VM/vmCDRom'
+        return "OVEHOSTED_VM/vmCDRom"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CDROM_UUID(self):
-        return 'OVEHOSTED_VM/cdromUUID'
+        return "OVEHOSTED_VM/cdromUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CONSOLE_UUID(self):
-        return 'OVEHOSTED_VM/consoleUUID'
+        return "OVEHOSTED_VM/consoleUUID"
 
     @ohostedattrs(
         answerfile=True,
     )
     def EMULATED_MACHINE(self):
-        return 'OVEHOSTED_VM/emulatedMachine'
+        return "OVEHOSTED_VM/emulatedMachine"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('OVF archive (for disk boot)'),
+        description=_("OVF archive (for disk boot)"),
     )
     def OVF(self):
-        return 'OVEHOSTED_VM/ovfArchive'
+        return "OVEHOSTED_VM/ovfArchive"
 
     @ohostedattrs(
         summary=True,
-        description=_('Appliance version'),
+        description=_("Appliance version"),
     )
     def APPLIANCE_VERSION(self):
-        return 'OVEHOSTED_VM/applianceVersion'
+        return "OVEHOSTED_VM/applianceVersion"
 
-    VM_PASSWD = 'OVEHOSTED_VDSM/passwd'
-    VM_PASSWD_VALIDITY_SECS = 'OVEHOSTED_VDSM/passwdValiditySecs'
-    SUBST = 'OVEHOSTED_VM/subst'
+    VM_PASSWD = "OVEHOSTED_VDSM/passwd"
+    VM_PASSWD_VALIDITY_SECS = "OVEHOSTED_VDSM/passwdValiditySecs"
+    SUBST = "OVEHOSTED_VM/subst"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Console type'),
+        description=_("Console type"),
     )
     def CONSOLE_TYPE(self):
-        return 'OVEHOSTED_VDSM/consoleType'
+        return "OVEHOSTED_VDSM/consoleType"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Restart engine VM after engine-setup'),
+        description=_("Restart engine VM after engine-setup"),
     )
     def AUTOMATE_VM_SHUTDOWN(self):
-        return 'OVEHOSTED_VM/automateVMShutdown'
+        return "OVEHOSTED_VM/automateVMShutdown"
 
-    ACCEPT_DOWNLOAD_EAPPLIANCE_RPM = 'OVEHOSTED_VM/acceptDownloadEApplianceRPM'
+    ACCEPT_DOWNLOAD_EAPPLIANCE_RPM = "OVEHOSTED_VM/acceptDownloadEApplianceRPM"
 
 
 @util.export
@@ -928,123 +849,123 @@ class CloudInit(object):
         answerfile=True,
     )
     def GENERATE_ISO(self):
-        return 'OVEHOSTED_VM/cloudInitISO'
+        return "OVEHOSTED_VM/cloudInitISO"
 
-    ROOTPWD = 'OVEHOSTED_VM/cloudinitRootPwd'
+    ROOTPWD = "OVEHOSTED_VM/cloudinitRootPwd"
 
     @ohostedattrs(
         answerfile=True,
     )
     def ROOT_SSH_ACCESS(self):
-        return 'OVEHOSTED_VM/rootSshAccess'
+        return "OVEHOSTED_VM/rootSshAccess"
 
     @ohostedattrs(
         answerfile=True,
     )
     def ROOT_SSH_PUBKEY(self):
-        return 'OVEHOSTED_VM/rootSshPubkey'
+        return "OVEHOSTED_VM/rootSshPubkey"
 
     @ohostedattrs(
         answerfile=True,
     )
     def APPLY_OPENSCAP_PROFILE(self):
-        return 'OVEHOSTED_VM/applyOpenScapProfile'
+        return "OVEHOSTED_VM/applyOpenScapProfile"
 
     @ohostedattrs(
         answerfile=True,
     )
     def OPENSCAP_PROFILE_NAME(self):
-        return 'OVEHOSTED_VM/OpenScapProfileName'
+        return "OVEHOSTED_VM/OpenScapProfileName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def ENABLE_FIPS(self):
-        return 'OVEHOSTED_VM/enableFips'
+        return "OVEHOSTED_VM/enableFips"
 
     @ohostedattrs(
         answerfile=True,
     )
     def INSTANCE_HOSTNAME(self):
-        return 'OVEHOSTED_VM/cloudinitInstanceHostName'
+        return "OVEHOSTED_VM/cloudinitInstanceHostName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def INSTANCE_DOMAINNAME(self):
-        return 'OVEHOSTED_VM/cloudinitInstanceDomainName'
+        return "OVEHOSTED_VM/cloudinitInstanceDomainName"
 
     @ohostedattrs(
         answerfile=True,
     )
     def EXECUTE_ESETUP(self):
-        return 'OVEHOSTED_VM/cloudinitExecuteEngineSetup'
+        return "OVEHOSTED_VM/cloudinitExecuteEngineSetup"
 
     @ohostedattrs(
         answerfile=True,
     )
     def VM_STATIC_CIDR(self):
-        return 'OVEHOSTED_VM/cloudinitVMStaticCIDR'
+        return "OVEHOSTED_VM/cloudinitVMStaticCIDR"
 
     @ohostedattrs(
         answerfile=True,
     )
     def VM_DNS(self):
-        return 'OVEHOSTED_VM/cloudinitVMDNS'
+        return "OVEHOSTED_VM/cloudinitVMDNS"
 
     @ohostedattrs(
         answerfile=True,
     )
     def VM_ETC_HOSTS(self):
-        return 'OVEHOSTED_VM/cloudinitVMETCHOSTS'
+        return "OVEHOSTED_VM/cloudinitVMETCHOSTS"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('Engine VM timezone'),
+        description=_("Engine VM timezone"),
     )
     def VM_TZ(self):
-        return 'OVEHOSTED_VM/cloudinitVMTZ'
+        return "OVEHOSTED_VM/cloudinitVMTZ"
 
 
 @util.export
 @util.codegen
 @ohostedattrsclass
 class VDSMEnv(object):
-    VDSMD_SERVICE = 'OVEHOSTED_VDSM/serviceName'
-    VDSM_UID = 'OVEHOSTED_VDSM/vdsmUid'
-    KVM_GID = 'OVEHOSTED_VDSM/kvmGid'
-    VDS_CLI = 'OVEHOSTED_VDSM/vdscli'
+    VDSMD_SERVICE = "OVEHOSTED_VDSM/serviceName"
+    VDSM_UID = "OVEHOSTED_VDSM/vdsmUid"
+    KVM_GID = "OVEHOSTED_VDSM/kvmGid"
+    VDS_CLI = "OVEHOSTED_VDSM/vdscli"
 
     @ohostedattrs(
         answerfile=True,
     )
     def PKI_SUBJECT(self):
-        return 'OVEHOSTED_VDSM/pkiSubject'
+        return "OVEHOSTED_VDSM/pkiSubject"
 
     @ohostedattrs(
         answerfile=True,
     )
     def CA_SUBJECT(self):
-        return 'OVEHOSTED_VDSM/caSubject'
+        return "OVEHOSTED_VDSM/caSubject"
 
     @ohostedattrs(
         answerfile=True,
         summary=True,
-        description=_('CPU Type'),
+        description=_("CPU Type"),
     )
     def VDSM_CPU(self):
-        return 'OVEHOSTED_VDSM/cpu'
+        return "OVEHOSTED_VDSM/cpu"
 
-    ENGINE_CPU = 'OVEHOSTED_VDSM/engineCpu'
-    USE_SSL = 'OVEHOSTED_VDSM/useSSL'
+    ENGINE_CPU = "OVEHOSTED_VDSM/engineCpu"
+    USE_SSL = "OVEHOSTED_VDSM/useSSL"
 
 
 @util.export
 @util.codegen
 class SanlockEnv(object):
-    SANLOCK_SERVICE = 'OVEHOSTED_SANLOCK/serviceName'
-    LOCKSPACE_NAME = 'OVEHOSTED_SANLOCK/lockspaceName'
+    SANLOCK_SERVICE = "OVEHOSTED_SANLOCK/serviceName"
+    LOCKSPACE_NAME = "OVEHOSTED_SANLOCK/lockspaceName"
 
 
 @util.export
@@ -1055,158 +976,157 @@ class NotificationsEnv(object):
         answerfile=True,
     )
     def SMTP_SERVER(self):
-        return 'OVEHOSTED_NOTIF/smtpServer'
+        return "OVEHOSTED_NOTIF/smtpServer"
 
     @ohostedattrs(
         answerfile=True,
     )
     def SMTP_PORT(self):
-        return 'OVEHOSTED_NOTIF/smtpPort'
+        return "OVEHOSTED_NOTIF/smtpPort"
 
     @ohostedattrs(
         answerfile=True,
     )
     def SOURCE_EMAIL(self):
-        return 'OVEHOSTED_NOTIF/sourceEmail'
+        return "OVEHOSTED_NOTIF/sourceEmail"
 
     @ohostedattrs(
         answerfile=True,
     )
     def DEST_EMAIL(self):
-        return 'OVEHOSTED_NOTIF/destEmail'
+        return "OVEHOSTED_NOTIF/destEmail"
 
-    DEFAULT_SMTP_SERVER = 'localhost'
+    DEFAULT_SMTP_SERVER = "localhost"
     DEFAULT_SMTP_PORT = 25
-    DEFAULT_SOURCE_EMAIL = 'root@localhost'
-    DEFAULT_DEST_EMAIL = 'root@localhost'
+    DEFAULT_SOURCE_EMAIL = "root@localhost"
+    DEFAULT_DEST_EMAIL = "root@localhost"
 
 
 @util.export
 @util.codegen
 class Stages(object):
-    CONFIG_STORAGE_EARLY = 'ohosted.storage.configuration.early'
-    CONFIG_STORAGE_LATE = 'ohosted.storage.configuration.late'
-    CONFIG_STORAGE_BLOCKD = 'ohosted.storage.blockd.configuration.available'
-    CONFIG_STORAGE_NFS = 'ohosted.storage.nfs.configuration.available'
-    CONFIG_STORAGE_HC = 'ohosted.storage.hc.configuration.available'
-    CONFIG_GATEWAY = 'ohosted.networking.gateway.configuration.available'
-    CONFIG_NETWORK_TEST = \
-        'ohosted.networking.network_test.configuration.available'
-    CONFIG_CLOUD_INIT_OPTIONS = 'ohosted.boot.configuration.cloud_init_options'
-    CONFIG_CLOUD_INIT_VM_NETWORKING = \
-        'ohosted.boot.configuration.cloud_init_vm_networking'
-    CONFIG_BACKUP_FILE = 'ohosted.configuration.backupfile'
-    REQUIRE_ANSWER_FILE = 'ohosted.core.require.answerfile'
-    CONFIG_OVF_IMPORT = 'ohosted.configuration.ovf'
-    CONFIG_OVF_IMPORT_ANSIBLE = 'ohosted.configuration.ovf.ansible'
-    VDSMD_START = 'ohosted.vdsm.started'
-    VDSMD_PKI = 'ohosted.vdsm.pki.available'
-    VDSMD_CONFIGURED = 'ohosted.vdsm.configured'
-    VDSMD_LATE_SETUP_READY = 'ohosted.vdsm.late_setup_ready'
-    SANLOCK_INITIALIZED = 'ohosted.sanlock.initialized'
-    STORAGE_AVAILABLE = 'ohosted.storage.available'
-    IMAGES_REPREPARED = 'ohosted.storage.imagesreprepared'
-    VM_IMAGE_AVAILABLE = 'ohosted.vm.image.available'
-    OVF_IMPORTED = 'ohosted.vm.ovf.imported'
-    BACKUP_INJECTED = 'ohosted.vm.backup.injected'
-    STORAGE_POOL_DESTROYED = 'ohosted.storage.pool.destroyed'
-    VM_CONFIGURED = 'ohosted.vm.state.configured'
-    VM_RUNNING = 'ohosted.vm.state.running'
-    VM_SHUTDOWN = 'ohosted.vm.state.shutdown'
-    ENGINE_VM_UP_CHECK = 'ohosted.engine.vm.up.check'
-    BRIDGE_AVAILABLE = 'ohosted.network.bridge.available'
-    BRIDGE_DETECTED = 'ohosted.network.bridge.detected'
-    GOT_HOSTNAME_FIRST_HOST = 'ohosted.network.hostname.got'
-    LIBVIRT_CONFIGURED = 'ohosted.libvirt.configured'
-    SAVE_CONFIG = 'ohosted.save.config'
-    SSHD_START = 'ohosted.sshd.started'
-    OS_INSTALLED = 'ohosted.vm.state.os.installed'
-    INSTALLED_VM_RUNNING = 'ohosted.vm.state.os.installed.running'
-    ENGINE_ALIVE = 'ohosted.engine.alive'
-    NET_FIREWALL_MANAGER_AVAILABLE = \
-        'ohosted.network.firewallmanager.available'
-    NET_FIREWALL_MANAGER_PROCESS_TEMPLATES = \
-        'ohosted.network.firewallmanager.templates.available'
-    NET_FIREWALL_FIRST_STAGE_CONFIGURED = \
-        'ohosted.network.firewallmanager.fsconfigured'
-    VDSMD_CONF_LOADED = 'ohosted.vdsm.conf.loaded'
-    HOST_ADDED = 'ohosted.engine.host.added'
-    VDSCLI_RECONNECTED = 'ohosted.engine.vdscli.reconnected'
-    HA_START = 'ohosted.engine.ha.start'
-    VDSM_LIBVIRT_CONFIGURED = 'ohosted.vdsm.libvirt.configured'
-    NODE_FILES_PERSIST_S = 'ohosted.node.files.persist.start'
-    NODE_FILES_PERSIST_E = 'ohosted.node.files.persist.end'
-    CONF_VOLUME_AVAILABLE = 'ohosted.conf.volume.available'
-    EXISTING_CONF_VOLUME_DETECTED = 'ohosted.conf.existing_volume.detected'
-    BROKER_CONF_AVAILABLE = 'ohosted.notifications.broker.conf.available'
-    ANSWER_FILE_AVAILABLE = 'ohosted.notifications.answerfile.available'
-    CONF_IMAGE_AVAILABLE = 'ohosted.notifications.confimage.available'
-    UPGRADED_APPLIANCE_RUNNING = 'ohosted.vm.state.upgraded.appliance.running'
-    CHECK_MAINTENANCE_MODE = 'ohosted.core.check.maintenance.mode'
-    CUSTOMIZATION_CA_ACQUIRED = 'ohosted.engine.ca.acquired.customization'
-    CUSTOMIZATION_CPU_MODEL = 'ohosted.vm.cpu.model.customization'
-    CUSTOMIZATION_CPU_NUMBER = 'ohosted.vm.cpu.model.number'
-    CUSTOMIZATION_MAC_ADDRESS = 'ohosted.vm.mac.customization'
-    CLOSEUP_CA_ACQUIRED = 'ohosted.engine.ca.acquired.closeup'
-    UPGRADE_CHECK_SD_SPACE = 'ohosted.upgrade.check.sd.space'
-    UPGRADE_CHECK_SPM_HOST = 'ohosted.upgrade.check.spm.host'
-    UPGRADE_CHECK_UPGRADE_REQUIREMENTS = 'ohosted.upgrade.check.upgrade.req'
-    UPGRADE_CHECK_UPGRADE_VERSIONS = 'ohosted.upgrade.check.upgrade.ver'
-    UPGRADE_BACKUP_DISK_CREATED = 'ohosted.upgrade.backup.disk.created'
-    UPGRADE_VM_SHUTDOWN = 'ohosted.upgrade.vm.state.shutdown'
-    UPGRADE_DISK_BACKUP_SAVED = 'ohosted.upgrade.disk.backup.saved'
-    UPGRADE_DISK_EXTENDED = 'ohosted.upgrade.disk.extended'
-    UPGRADE_BACKUP_DISK_REGISTERED = 'ohosted.upgrade.backup.disk.registered'
-    UPGRADED_DATACENTER_UP = 'ohosted.upgrade.datacenter.up'
+    CONFIG_STORAGE_EARLY = "ohosted.storage.configuration.early"
+    CONFIG_STORAGE_LATE = "ohosted.storage.configuration.late"
+    CONFIG_STORAGE_BLOCKD = "ohosted.storage.blockd.configuration.available"
+    CONFIG_STORAGE_NFS = "ohosted.storage.nfs.configuration.available"
+    CONFIG_STORAGE_HC = "ohosted.storage.hc.configuration.available"
+    CONFIG_GATEWAY = "ohosted.networking.gateway.configuration.available"
+    CONFIG_NETWORK_TEST = "ohosted.networking.network_test.configuration.available"
+    CONFIG_CLOUD_INIT_OPTIONS = "ohosted.boot.configuration.cloud_init_options"
+    CONFIG_CLOUD_INIT_VM_NETWORKING = (
+        "ohosted.boot.configuration.cloud_init_vm_networking"
+    )
+    CONFIG_BACKUP_FILE = "ohosted.configuration.backupfile"
+    REQUIRE_ANSWER_FILE = "ohosted.core.require.answerfile"
+    CONFIG_OVF_IMPORT = "ohosted.configuration.ovf"
+    CONFIG_OVF_IMPORT_ANSIBLE = "ohosted.configuration.ovf.ansible"
+    VDSMD_START = "ohosted.vdsm.started"
+    VDSMD_PKI = "ohosted.vdsm.pki.available"
+    VDSMD_CONFIGURED = "ohosted.vdsm.configured"
+    VDSMD_LATE_SETUP_READY = "ohosted.vdsm.late_setup_ready"
+    SANLOCK_INITIALIZED = "ohosted.sanlock.initialized"
+    STORAGE_AVAILABLE = "ohosted.storage.available"
+    IMAGES_REPREPARED = "ohosted.storage.imagesreprepared"
+    VM_IMAGE_AVAILABLE = "ohosted.vm.image.available"
+    OVF_IMPORTED = "ohosted.vm.ovf.imported"
+    BACKUP_INJECTED = "ohosted.vm.backup.injected"
+    STORAGE_POOL_DESTROYED = "ohosted.storage.pool.destroyed"
+    VM_CONFIGURED = "ohosted.vm.state.configured"
+    VM_RUNNING = "ohosted.vm.state.running"
+    VM_SHUTDOWN = "ohosted.vm.state.shutdown"
+    ENGINE_VM_UP_CHECK = "ohosted.engine.vm.up.check"
+    BRIDGE_AVAILABLE = "ohosted.network.bridge.available"
+    BRIDGE_DETECTED = "ohosted.network.bridge.detected"
+    GOT_HOSTNAME_FIRST_HOST = "ohosted.network.hostname.got"
+    LIBVIRT_CONFIGURED = "ohosted.libvirt.configured"
+    SAVE_CONFIG = "ohosted.save.config"
+    SSHD_START = "ohosted.sshd.started"
+    OS_INSTALLED = "ohosted.vm.state.os.installed"
+    INSTALLED_VM_RUNNING = "ohosted.vm.state.os.installed.running"
+    ENGINE_ALIVE = "ohosted.engine.alive"
+    NET_FIREWALL_MANAGER_AVAILABLE = "ohosted.network.firewallmanager.available"
+    NET_FIREWALL_MANAGER_PROCESS_TEMPLATES = (
+        "ohosted.network.firewallmanager.templates.available"
+    )
+    NET_FIREWALL_FIRST_STAGE_CONFIGURED = "ohosted.network.firewallmanager.fsconfigured"
+    VDSMD_CONF_LOADED = "ohosted.vdsm.conf.loaded"
+    HOST_ADDED = "ohosted.engine.host.added"
+    VDSCLI_RECONNECTED = "ohosted.engine.vdscli.reconnected"
+    HA_START = "ohosted.engine.ha.start"
+    VDSM_LIBVIRT_CONFIGURED = "ohosted.vdsm.libvirt.configured"
+    NODE_FILES_PERSIST_S = "ohosted.node.files.persist.start"
+    NODE_FILES_PERSIST_E = "ohosted.node.files.persist.end"
+    CONF_VOLUME_AVAILABLE = "ohosted.conf.volume.available"
+    EXISTING_CONF_VOLUME_DETECTED = "ohosted.conf.existing_volume.detected"
+    BROKER_CONF_AVAILABLE = "ohosted.notifications.broker.conf.available"
+    ANSWER_FILE_AVAILABLE = "ohosted.notifications.answerfile.available"
+    CONF_IMAGE_AVAILABLE = "ohosted.notifications.confimage.available"
+    UPGRADED_APPLIANCE_RUNNING = "ohosted.vm.state.upgraded.appliance.running"
+    CHECK_MAINTENANCE_MODE = "ohosted.core.check.maintenance.mode"
+    CUSTOMIZATION_CA_ACQUIRED = "ohosted.engine.ca.acquired.customization"
+    CUSTOMIZATION_CPU_MODEL = "ohosted.vm.cpu.model.customization"
+    CUSTOMIZATION_CPU_NUMBER = "ohosted.vm.cpu.model.number"
+    CUSTOMIZATION_MAC_ADDRESS = "ohosted.vm.mac.customization"
+    CLOSEUP_CA_ACQUIRED = "ohosted.engine.ca.acquired.closeup"
+    UPGRADE_CHECK_SD_SPACE = "ohosted.upgrade.check.sd.space"
+    UPGRADE_CHECK_SPM_HOST = "ohosted.upgrade.check.spm.host"
+    UPGRADE_CHECK_UPGRADE_REQUIREMENTS = "ohosted.upgrade.check.upgrade.req"
+    UPGRADE_CHECK_UPGRADE_VERSIONS = "ohosted.upgrade.check.upgrade.ver"
+    UPGRADE_BACKUP_DISK_CREATED = "ohosted.upgrade.backup.disk.created"
+    UPGRADE_VM_SHUTDOWN = "ohosted.upgrade.vm.state.shutdown"
+    UPGRADE_DISK_BACKUP_SAVED = "ohosted.upgrade.disk.backup.saved"
+    UPGRADE_DISK_EXTENDED = "ohosted.upgrade.disk.extended"
+    UPGRADE_BACKUP_DISK_REGISTERED = "ohosted.upgrade.backup.disk.registered"
+    UPGRADED_DATACENTER_UP = "ohosted.upgrade.datacenter.up"
 
-    DIALOG_TITLES_S_VM = 'ohosted.dialog.titles.vm.start'
-    DIALOG_TITLES_E_VM = 'ohosted.dialog.titles.vm.end'
-    DIALOG_TITLES_S_NETWORK = 'ohosted.dialog.titles.network.start'
-    DIALOG_TITLES_E_NETWORK = 'ohosted.dialog.titles.network.end'
-    DIALOG_TITLES_S_ENGINE = 'ohosted.dialog.titles.engine.start'
-    DIALOG_TITLES_E_ENGINE = 'ohosted.dialog.titles.engine.end'
-    DIALOG_TITLES_S_STORAGE = 'ohosted.dialog.titles.storage.start'
-    DIALOG_TITLES_E_STORAGE = 'ohosted.dialog.titles.storage.end'
+    DIALOG_TITLES_S_VM = "ohosted.dialog.titles.vm.start"
+    DIALOG_TITLES_E_VM = "ohosted.dialog.titles.vm.end"
+    DIALOG_TITLES_S_NETWORK = "ohosted.dialog.titles.network.start"
+    DIALOG_TITLES_E_NETWORK = "ohosted.dialog.titles.network.end"
+    DIALOG_TITLES_S_ENGINE = "ohosted.dialog.titles.engine.start"
+    DIALOG_TITLES_E_ENGINE = "ohosted.dialog.titles.engine.end"
+    DIALOG_TITLES_S_STORAGE = "ohosted.dialog.titles.storage.start"
+    DIALOG_TITLES_E_STORAGE = "ohosted.dialog.titles.storage.end"
 
-    ANSIBLE_BOOTSTRAP_LOCAL_VM = 'ohosted.ansible.bootstrap.local.vm'
-    ANSIBLE_CREATE_SD = 'ohosted.ansible.create.storage.domain'
-    ANSIBLE_CREATE_TARGET_VM = 'ohosted.ansible.create.target.vm'
-    ANSIBLE_CUSTOMIZE_DISK_SIZE = 'ohosted.ansible.disk.customized'
+    ANSIBLE_BOOTSTRAP_LOCAL_VM = "ohosted.ansible.bootstrap.local.vm"
+    ANSIBLE_CREATE_SD = "ohosted.ansible.create.storage.domain"
+    ANSIBLE_CREATE_TARGET_VM = "ohosted.ansible.create.target.vm"
+    ANSIBLE_CUSTOMIZE_DISK_SIZE = "ohosted.ansible.disk.customized"
 
 
 @util.export
 @util.codegen
 class Defaults(object):
-    DEFAULT_STORAGE_DOMAIN_NAME = 'hosted_storage'
-    DEFAULT_STORAGE_DATACENTER_NAME = 'hosted_datacenter'
-    DEFAULT_DATACENTER_NAME = 'Default'
-    DEFAULT_CLUSTER_NAME = 'Default'
-    DEFAULT_VDSMD_SERVICE = 'vdsmd'
-    DEFAULT_SYSTEM_USER_VDSM = 'vdsm'
-    DEFAULT_SYSTEM_GROUP_KVM = 'kvm'
-    DEFAULT_SANLOCK_SERVICE = 'sanlock'
-    DEFAULT_LOCKSPACE_NAME = 'hosted-engine'
-    DEFAULT_IMAGE_DESC = 'Hosted Engine Image'
+    DEFAULT_STORAGE_DOMAIN_NAME = "hosted_storage"
+    DEFAULT_STORAGE_DATACENTER_NAME = "hosted_datacenter"
+    DEFAULT_DATACENTER_NAME = "Default"
+    DEFAULT_CLUSTER_NAME = "Default"
+    DEFAULT_VDSMD_SERVICE = "vdsmd"
+    DEFAULT_SYSTEM_USER_VDSM = "vdsm"
+    DEFAULT_SYSTEM_GROUP_KVM = "kvm"
+    DEFAULT_SANLOCK_SERVICE = "sanlock"
+    DEFAULT_LOCKSPACE_NAME = "hosted-engine"
+    DEFAULT_IMAGE_DESC = "Hosted Engine Image"
     DEFAULT_IMAGE_SIZE_GB = 25  # based on minimum requirements.
     MINIMAL_MEM_SIZE_MB = 4096  # based on minimum requirements.
     DEFAULT_CONF_IMAGE_SIZE_GB = 1
-    DEFAULT_CDROM = '/dev/null'
-    DEFAULT_BRIDGE_IF = 'em1'
-    DEFAULT_BRIDGE_NAME = 'ovirtmgmt'
-    DEFAULT_PKI_SUBJECT = '/C=EN/L=Test/O=Test/CN=Test'
-    DEFAULT_CA_SUBJECT = '/C=EN/L=Test/O=Test/CN=TestCA'  # must be != above
+    DEFAULT_CDROM = "/dev/null"
+    DEFAULT_BRIDGE_IF = "em1"
+    DEFAULT_BRIDGE_NAME = "ovirtmgmt"
+    DEFAULT_PKI_SUBJECT = "/C=EN/L=Test/O=Test/CN=Test"
+    DEFAULT_CA_SUBJECT = "/C=EN/L=Test/O=Test/CN=TestCA"  # must be != above
     DEFAULT_VM_PASSWD_VALIDITY_SECS = 10800  # 3 hours to for engine install
     DEFAULT_VM_VCPUS = 2  # based on minimum requirements.
     DEFAULT_SSHD_PORT = 22
-    DEFAULT_EMULATED_MACHINE = 'pc'
-    DEFAULT_RHEL_EMULATED_MACHINE = 'pc-i440fx-rhel7.3.0'
+    DEFAULT_EMULATED_MACHINE = "pc"
+    DEFAULT_RHEL_EMULATED_MACHINE = "pc-i440fx-rhel7.3.0"
     DEFAULT_ISCSI_PORT = 3260
     DEFAULT_ENGINE_SETUP_TIMEOUT = 1800
     DEFAULT_ENGINE_API_TIMEOUT = 30
     DEFAULT_ENGINE_API_RETRY_ATTEMPTS = 5
-    DEFAULT_STATE_TRANS_NOTIFICATION = 'maintenance|start|stop|migrate|up|down'
-    DEFAULT_TEMPDIR = '/var/tmp'
-    DEFAULT_ADMIN_USERNAME = 'admin@internal'
+    DEFAULT_STATE_TRANS_NOTIFICATION = "maintenance|start|stop|migrate|up|down"
+    DEFAULT_TEMPDIR = "/var/tmp"
+    DEFAULT_ADMIN_USERNAME = "admin@internal"
     ANSIBLE_RECOMMENDED_APPLIANCE_VCPUS = 4  # based on appliance definition
     ANSIBLE_RECOMMENDED_APPLIANCE_MEM_SIZE_MB = 16384  # based on appliance def
 
@@ -1214,21 +1134,21 @@ class Defaults(object):
 @util.export
 @util.codegen
 class Confirms(object):
-    DEPLOY_PROCEED = 'DEPLOY_PROCEED'
-    CPU_PROCEED = 'CPU_PROCEED'
-    DISK_PROCEED = 'DISK_PROCEED'
-    MEMORY_PROCEED = 'MEMORY_PROCEED'
-    TMUX_PROCEED = 'TMUX_PROCEED'
-    SETTINGS = 'SETTINGS_PROCEED'
-    UPGRADE_DISK_RESIZE_PROCEED = 'UPGRADE_DISK_RESIZE_PROCEED'
-    FORCE_IP_PROCEED = 'FORCE_IP_PROCEED'
+    DEPLOY_PROCEED = "DEPLOY_PROCEED"
+    CPU_PROCEED = "CPU_PROCEED"
+    DISK_PROCEED = "DISK_PROCEED"
+    MEMORY_PROCEED = "MEMORY_PROCEED"
+    TMUX_PROCEED = "TMUX_PROCEED"
+    SETTINGS = "SETTINGS_PROCEED"
+    UPGRADE_DISK_RESIZE_PROCEED = "UPGRADE_DISK_RESIZE_PROCEED"
+    FORCE_IP_PROCEED = "FORCE_IP_PROCEED"
 
 
 @util.export
 @util.codegen
 class FirstHostEnv(object):
-    SKIP_SHARED_STORAGE_ANSWERF = 'OVEHOSTED_FIRST_HOST/skipSharedStorageAF'
-    DEPLOY_WITH_HE_35_HOSTS = 'OVEHOSTED_FIRST_HOST/deployWithHE35Hosts'
+    SKIP_SHARED_STORAGE_ANSWERF = "OVEHOSTED_FIRST_HOST/skipSharedStorageAF"
+    DEPLOY_WITH_HE_35_HOSTS = "OVEHOSTED_FIRST_HOST/deployWithHE35Hosts"
 
 
 # vim: expandtab tabstop=4 shiftwidth=4

--- a/src/ovirt_hosted_engine_setup/constants.py
+++ b/src/ovirt_hosted_engine_setup/constants.py
@@ -114,6 +114,7 @@ class VDSMConstants(object):
     ISCSI_DOMAIN = 3
     POSIXFS_DOMAIN = 6
     GLUSTERFS_DOMAIN = 7
+    NVMEOF_DOMAIN = 12
     DATA_DOMAIN = 1
 
 
@@ -128,6 +129,7 @@ class StorageDomainType(object):
     CIFS = "CIFS"
     SHAREDFS = "SHAREDFS"
     GLUSTERFS = "GLUSTERFS"
+    NVMEOF = "NVMEOF"
 
 
 @util.export

--- a/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
+++ b/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
@@ -20,7 +20,6 @@
 
 """Storage domain plugin."""
 
-
 import gettext
 import netaddr
 import re
@@ -33,7 +32,7 @@ from ovirt_hosted_engine_setup import constants as ohostedcons
 
 
 def _(m):
-    return gettext.dgettext(message=m, domain='ovirt-hosted-engine-setup')
+    return gettext.dgettext(message=m, domain="ovirt-hosted-engine-setup")
 
 
 @util.export
@@ -45,10 +44,10 @@ class Plugin(plugin.PluginBase):
 
     def _query_nfs_version(self):
         return self.dialog.queryString(
-            name='OVEHOSTED_STORAGE_NFS_VERSION',
+            name="OVEHOSTED_STORAGE_NFS_VERSION",
             note=_(
-                'Please specify the nfs version '
-                'you would like to use (@VALUES@)[@DEFAULT@]: '
+                "Please specify the nfs version "
+                "you would like to use (@VALUES@)[@DEFAULT@]: "
             ),
             prompt=True,
             caseSensitive=True,
@@ -65,10 +64,10 @@ class Plugin(plugin.PluginBase):
 
     def _query_connection_path(self):
         return self.dialog.queryString(
-            name='OVEHOSTED_STORAGE_DOMAIN_CONNECTION',
+            name="OVEHOSTED_STORAGE_DOMAIN_CONNECTION",
             note=_(
-                'Please specify the full shared storage '
-                'connection path to use (example: host:/path): '
+                "Please specify the full shared storage "
+                "connection path to use (example: host:/path): "
             ),
             prompt=True,
             caseSensitive=True,
@@ -76,15 +75,15 @@ class Plugin(plugin.PluginBase):
 
     def _query_mnt_options(self, mnt_options):
         return self.dialog.queryString(
-            name='OVEHOSTED_STORAGE_DOMAIN_MNT_OPTIONS',
+            name="OVEHOSTED_STORAGE_DOMAIN_MNT_OPTIONS",
             note=_(
-                'If needed, specify additional mount options for '
-                'the connection to the hosted-engine storage'
-                'domain (example: rsize=32768,wsize=32768) [@DEFAULT@]: '
+                "If needed, specify additional mount options for "
+                "the connection to the hosted-engine storage"
+                "domain (example: rsize=32768,wsize=32768) [@DEFAULT@]: "
             ),
             prompt=True,
             caseSensitive=True,
-            default=mnt_options if mnt_options else '',
+            default=mnt_options if mnt_options else "",
         )
 
     def _query_iscsi_portal(self):
@@ -92,130 +91,116 @@ class Plugin(plugin.PluginBase):
         address = None
         while not valid:
             address = self.dialog.queryString(
-                name='OVEHOSTED_STORAGE_ISCSI_IP_ADDR',
-                note=_(
-                    'Please specify the iSCSI portal IP address: '
-                ),
+                name="OVEHOSTED_STORAGE_ISCSI_IP_ADDR",
+                note=_("Please specify the iSCSI portal IP address: "),
                 prompt=True,
                 caseSensitive=True,
             )
             if address:
                 valid = True
-                for a in address.split(','):
+                for a in address.split(","):
                     try:
                         netaddr.IPAddress(a)
                         valid &= True
                     except netaddr.core.AddrFormatError as ve:
-                        self.logger.error(_(
-                            'Invalid IP address: {a} - {ve}'
-                        ).format(
-                            a=a,
-                            ve=ve,
-                        ))
+                        self.logger.error(
+                            _("Invalid IP address: {a} - {ve}").format(
+                                a=a,
+                                ve=ve,
+                            )
+                        )
                         valid = False
             if not valid:
-                self.logger.error(_('Address must be a valid IP address'))
+                self.logger.error(_("Address must be a valid IP address"))
         return address
 
     def _query_iscsi_port(self):
         valid = False
         while not valid:
             port = self.dialog.queryString(
-                name='OVEHOSTED_STORAGE_ISCSI_IP_PORT',
-                note=_(
-                    'Please specify the iSCSI portal port [@DEFAULT@]: '
-                ),
+                name="OVEHOSTED_STORAGE_ISCSI_IP_PORT",
+                note=_("Please specify the iSCSI portal port [@DEFAULT@]: "),
                 prompt=True,
                 caseSensitive=True,
                 default=ohostedcons.Defaults.DEFAULT_ISCSI_PORT,
             )
             try:
-                for p in port.split(','):
+                for p in port.split(","):
                     int_port = int(p)
                     if int_port > 0 and int_port < 65536:
                         valid = True
                     else:
-                        raise ValueError(_('Port must be a valid port number'))
+                        raise ValueError(_("Port must be a valid port number"))
             except ValueError:
-                self.logger.debug('exception', exc_info=True)
-                self.logger.error(_('Port must be a valid port number'))
+                self.logger.debug("exception", exc_info=True)
+                self.logger.error(_("Port must be a valid port number"))
         return port
 
     def _query_iscsi_username(self, discover):
         valid = False
         username = None
         if discover:
-            qtype = _('discover')
+            qtype = _("discover")
         else:
-            qtype = _('portal login')
+            qtype = _("portal login")
         while not valid:
             valid = True
             username = self.dialog.queryString(
-                name='OVEHOSTED_STORAGE_ISCSI_USER',
-                note=_(
-                    'Please specify the iSCSI {qtype} user: '
-                ).format(qtype=qtype),
+                name="OVEHOSTED_STORAGE_ISCSI_USER",
+                note=_("Please specify the iSCSI {qtype} user: ").format(qtype=qtype),
                 prompt=True,
                 caseSensitive=True,
-                default='',
+                default="",
             )
             if len(username) > ohostedcons.Const.MAX_STORAGE_USERNAME_LENGTH:
                 valid = False
-                self.logger.error(_(
-                    'Username should not be longer than {i} characters.'
-                ).format(i=ohostedcons.Const.MAX_STORAGE_USERNAME_LENGTH))
+                self.logger.error(
+                    _("Username should not be longer than {i} characters.").format(
+                        i=ohostedcons.Const.MAX_STORAGE_USERNAME_LENGTH
+                    )
+                )
         return username
 
     def _query_iscsi_password(self, discover):
         valid = False
         password = None
         if discover:
-            qtype = _('discover')
+            qtype = _("discover")
         else:
-            qtype = _('portal login')
+            qtype = _("portal login")
         while not valid:
             valid = True
             password = self.dialog.queryString(
-                name='OVEHOSTED_STORAGE_ISCSI_PASSWORD',
-                note=_(
-                    'Please specify the iSCSI {qtype} password: '
-                ).format(qtype=qtype),
+                name="OVEHOSTED_STORAGE_ISCSI_PASSWORD",
+                note=_("Please specify the iSCSI {qtype} password: ").format(
+                    qtype=qtype
+                ),
                 prompt=True,
                 caseSensitive=True,
                 hidden=True,
-                default='',
+                default="",
             )
             if len(password) > ohostedcons.Const.MAX_STORAGE_PASSWORD_LENGTH:
                 valid = False
-                self.logger.error(_(
-                    'Username should not be longer than {i} characters.'
-                ).format(i=ohostedcons.Const.MAX_STORAGE_PASSWORD_LENGTH))
+                self.logger.error(
+                    _("Username should not be longer than {i} characters.").format(
+                        i=ohostedcons.Const.MAX_STORAGE_PASSWORD_LENGTH
+                    )
+                )
         return password
 
-    def _query_iscsi_target(
-            self,
-            discover_username,
-            discover_password,
-            portal,
-            port
-    ):
+    def _query_iscsi_target(self, discover_username, discover_password, portal, port):
         iscsi_discover_vars = {
-            'he_fqdn': self.environment[
+            "he_fqdn": self.environment[
                 ohostedcons.NetworkEnv.OVIRT_HOSTED_ENGINE_FQDN
             ],
-            'he_host_name': self.environment[
-                ohostedcons.EngineEnv.APP_HOST_NAME
-            ],
-            'he_admin_password': self.environment[
-                ohostedcons.EngineEnv.ADMIN_PASSWORD
-            ],
-            'he_admin_username': self.environment[
-                ohostedcons.EngineEnv.ADMIN_USERNAME
-            ],
-            'he_iscsi_discover_username': discover_username,
-            'he_iscsi_discover_password': discover_password,
-            'he_iscsi_portal_addr': portal,
-            'he_iscsi_portal_port': port,
+            "he_host_name": self.environment[ohostedcons.EngineEnv.APP_HOST_NAME],
+            "he_admin_password": self.environment[ohostedcons.EngineEnv.ADMIN_PASSWORD],
+            "he_admin_username": self.environment[ohostedcons.EngineEnv.ADMIN_USERNAME],
+            "he_iscsi_discover_username": discover_username,
+            "he_iscsi_discover_password": discover_password,
+            "he_iscsi_portal_addr": portal,
+            "he_iscsi_portal_port": port,
         }
         ah = ansible_utils.AnsibleHelper(
             tags=ohostedcons.Const.HE_TAG_ISCSI_DISCOVER,
@@ -224,114 +209,87 @@ class Plugin(plugin.PluginBase):
                 ohostedcons.CoreEnv.ANSIBLE_USER_EXTRA_VARS
             ),
         )
-        self.logger.info(_('Discovering iSCSI targets'))
+        self.logger.info(_("Discovering iSCSI targets"))
         r = ah.run()
         self.logger.debug(r)
         try:
-            values = r['otopi_iscsi_targets']['iscsi_targets_struct']
+            values = r["otopi_iscsi_targets"]["iscsi_targets_struct"]
         except KeyError:
-            raise RuntimeError(_('Unable to find any target'))
+            raise RuntimeError(_("Unable to find any target"))
         self.logger.debug(values)
         f_targets = []
         found = {}
         for v in values:
             self.logger.debug(v)
-            target = v['target']
-            tpgt = v['portal'].split(',')[1]
+            target = v["target"]
+            tpgt = v["portal"].split(",")[1]
             if target not in found:
                 found[target] = {}
             if tpgt not in found[target]:
                 found[target][tpgt] = []
-            found[target][tpgt].append(
-                {
-                    'address': v['address'],
-                    'port': v['port']
-                }
-            )
+            found[target][tpgt].append({"address": v["address"], "port": v["port"]})
         self.logger.debug(found)
         for target in found:
             for tpgt in found[target]:
                 f_targets.append(
                     {
-                        'index': str(len(f_targets)+1),
-                        'target': target,
-                        'tpgt': tpgt,
-                        'address_port_l': found[target][tpgt]
+                        "index": str(len(f_targets) + 1),
+                        "target": target,
+                        "tpgt": tpgt,
+                        "address_port_l": found[target][tpgt],
                     }
                 )
-        target_list = ''
+        target_list = ""
         for entry in f_targets:
             target_list += _(
-                '\t[{index}]\t{target}\n\t\tTPGT: {tpgt}, portals:\n'
+                "\t[{index}]\t{target}\n\t\tTPGT: {tpgt}, portals:\n"
             ).format(
-                index=entry['index'],
-                target=entry['target'],
-                tpgt=entry['tpgt'],
+                index=entry["index"],
+                target=entry["target"],
+                tpgt=entry["tpgt"],
             )
-            for pp in entry['address_port_l']:
-                target_list += _(
-                    '\t\t\t{portal}:{port}\n'
-                ).format(
-                    portal=pp['address'],
-                    port=pp['port'],
+            for pp in entry["address_port_l"]:
+                target_list += _("\t\t\t{portal}:{port}\n").format(
+                    portal=pp["address"],
+                    port=pp["port"],
                 )
-            target_list += '\n'
+            target_list += "\n"
 
         self.dialog.note(
-            _(
-                'The following targets have been found:\n'
-                '{target_list}'
-            ).format(
+            _("The following targets have been found:\n{target_list}").format(
                 target_list=target_list,
             )
         )
         s_target = self.dialog.queryString(
-            name='OVEHOSTED_STORAGE_ISCSI_TARGET',
-            note=_(
-                'Please select a target '
-                '(@VALUES@) [@DEFAULT@]: '
-            ),
+            name="OVEHOSTED_STORAGE_ISCSI_TARGET",
+            note=_("Please select a target (@VALUES@) [@DEFAULT@]: "),
             prompt=True,
             caseSensitive=True,
-            default='1',
-            validValues=[i['index'] for i in f_targets],
+            default="1",
+            validValues=[i["index"] for i in f_targets],
         )
-        apl = f_targets[int(s_target)-1]['address_port_l']
+        apl = f_targets[int(s_target) - 1]["address_port_l"]
         return (
-            f_targets[int(s_target)-1]['target'],
-            f_targets[int(s_target)-1]['tpgt'],
-            ','.join([x['address'] for x in apl]),
-            ','.join([str(x['port']) for x in apl]),
+            f_targets[int(s_target) - 1]["target"],
+            f_targets[int(s_target) - 1]["tpgt"],
+            ",".join([x["address"] for x in apl]),
+            ",".join([str(x["port"]) for x in apl]),
         )
 
-    def _query_iscsi_lunid(
-        self,
-        username,
-        password,
-        portal,
-        port,
-        target,
-        tpgt
-    ):
+    def _query_iscsi_lunid(self, username, password, portal, port, target, tpgt):
         iscsi_getdevices_vars = {
-            'he_fqdn': self.environment[
+            "he_fqdn": self.environment[
                 ohostedcons.NetworkEnv.OVIRT_HOSTED_ENGINE_FQDN
             ],
-            'he_host_name': self.environment[
-                ohostedcons.EngineEnv.APP_HOST_NAME
-            ],
-            'he_admin_password': self.environment[
-                ohostedcons.EngineEnv.ADMIN_PASSWORD
-            ],
-            'he_admin_username': self.environment[
-                ohostedcons.EngineEnv.ADMIN_USERNAME
-            ],
-            'he_iscsi_username': username,
-            'he_iscsi_password': password,
-            'he_iscsi_portal_addr': portal,
-            'he_iscsi_portal_port': port,
-            'he_iscsi_target': target,
-            'he_iscsi_tpgt': tpgt,
+            "he_host_name": self.environment[ohostedcons.EngineEnv.APP_HOST_NAME],
+            "he_admin_password": self.environment[ohostedcons.EngineEnv.ADMIN_PASSWORD],
+            "he_admin_username": self.environment[ohostedcons.EngineEnv.ADMIN_USERNAME],
+            "he_iscsi_username": username,
+            "he_iscsi_password": password,
+            "he_iscsi_portal_addr": portal,
+            "he_iscsi_portal_port": port,
+            "he_iscsi_target": target,
+            "he_iscsi_tpgt": tpgt,
         }
         ah = ansible_utils.AnsibleHelper(
             tags=ohostedcons.Const.HE_TAG_ISCSI_GETDEVICES,
@@ -340,50 +298,30 @@ class Plugin(plugin.PluginBase):
                 ohostedcons.CoreEnv.ANSIBLE_USER_EXTRA_VARS
             ),
         )
-        self.logger.info(_('Getting iSCSI LUNs list'))
+        self.logger.info(_("Getting iSCSI LUNs list"))
         r = ah.run()
         self.logger.debug(r)
         available_luns = []
-        if (
-            'otopi_iscsi_devices' in r
-        ):
+        if "otopi_iscsi_devices" in r:
             if (
-                'ansible_facts' in r['otopi_iscsi_devices'] and
-                'ovirt_host_storages' in r[
-                    'otopi_iscsi_devices'
-                ][
-                    'ansible_facts'
-                ]
+                "ansible_facts" in r["otopi_iscsi_devices"]
+                and "ovirt_host_storages" in r["otopi_iscsi_devices"]["ansible_facts"]
             ):
-                available_luns = r[
-                    'otopi_iscsi_devices'
-                ][
-                    'ansible_facts'
-                ]['ovirt_host_storages']
-            elif (
-                'ovirt_host_storages' in r['otopi_iscsi_devices']
-            ):
-                available_luns = r[
-                    'otopi_iscsi_devices'
-                ][
-                    'ovirt_host_storages'
+                available_luns = r["otopi_iscsi_devices"]["ansible_facts"][
+                    "ovirt_host_storages"
                 ]
+            elif "ovirt_host_storages" in r["otopi_iscsi_devices"]:
+                available_luns = r["otopi_iscsi_devices"]["ovirt_host_storages"]
         return self._select_lun(available_luns)
 
     def _query_fc_lunid(self):
         fc_getdevices_vars = {
-            'he_fqdn': self.environment[
+            "he_fqdn": self.environment[
                 ohostedcons.NetworkEnv.OVIRT_HOSTED_ENGINE_FQDN
             ],
-            'he_host_name': self.environment[
-                ohostedcons.EngineEnv.APP_HOST_NAME
-            ],
-            'he_admin_password': self.environment[
-                ohostedcons.EngineEnv.ADMIN_PASSWORD
-            ],
-            'he_admin_username': self.environment[
-                ohostedcons.EngineEnv.ADMIN_USERNAME
-            ],
+            "he_host_name": self.environment[ohostedcons.EngineEnv.APP_HOST_NAME],
+            "he_admin_password": self.environment[ohostedcons.EngineEnv.ADMIN_PASSWORD],
+            "he_admin_username": self.environment[ohostedcons.EngineEnv.ADMIN_USERNAME],
         }
         ansible_helper = ansible_utils.AnsibleHelper(
             tags=ohostedcons.Const.HE_TAG_FC_GETDEVICES,
@@ -392,155 +330,205 @@ class Plugin(plugin.PluginBase):
                 ohostedcons.CoreEnv.ANSIBLE_USER_EXTRA_VARS
             ),
         )
-        self.logger.info(_('Getting Fibre Channel LUNs list'))
+        self.logger.info(_("Getting Fibre Channel LUNs list"))
         r = ansible_helper.run()
         self.logger.debug(r)
         available_luns = []
-        if (
-            'otopi_fc_devices' in r
-        ):
+        if "otopi_fc_devices" in r:
             if (
-                'ansible_facts' in r['otopi_fc_devices'] and
-                'ovirt_host_storages' in r['otopi_fc_devices']['ansible_facts']
+                "ansible_facts" in r["otopi_fc_devices"]
+                and "ovirt_host_storages" in r["otopi_fc_devices"]["ansible_facts"]
             ):
-                available_luns = r['otopi_fc_devices'][
-                    'ansible_facts'
-                ]['ovirt_host_storages']
-            elif (
-                'ovirt_host_storages' in r['otopi_fc_devices']
+                available_luns = r["otopi_fc_devices"]["ansible_facts"][
+                    "ovirt_host_storages"
+                ]
+            elif "ovirt_host_storages" in r["otopi_fc_devices"]:
+                available_luns = r["otopi_fc_devices"]["ovirt_host_storages"]
+        return self._select_lun(available_luns)
+
+    def _query_nvmeof_address(self):
+        valid = False
+        address = None
+        while not valid:
+            address = self.dialog.queryString(
+                name="OVEHOSTED_STORAGE_NVMEOF_ADDR",
+                note=_("Please specify the NVMe-oF target IP address: "),
+                prompt=True,
+                caseSensitive=True,
+            )
+            if address:
+                valid = True
+                for a in address.split(","):
+                    try:
+                        netaddr.IPAddress(a)
+                        valid &= True
+                    except netaddr.core.AddrFormatError as ve:
+                        self.logger.error(
+                            _("Invalid IP address: {a} - {ve}").format(
+                                a=a,
+                                ve=ve,
+                            )
+                        )
+                        valid = False
+            if not valid:
+                self.logger.error(_("Address must be a valid IP address"))
+        return address
+
+    def _query_nvmeof_port(self):
+        valid = False
+        while not valid:
+            port = self.dialog.queryString(
+                name="OVEHOSTED_STORAGE_NVMEOF_PORT",
+                note=_("Please specify the NVMe-oF target port [@DEFAULT@]: "),
+                prompt=True,
+                caseSensitive=True,
+                default=4420,
+            )
+            try:
+                int_port = int(port)
+                if int_port > 0 and int_port < 65536:
+                    valid = True
+                else:
+                    raise ValueError(_("Port must be a valid port number"))
+            except ValueError:
+                self.logger.error(_("Port must be a valid port number"))
+        return port
+
+    def _query_nvmeof_nqn(self):
+        return self.dialog.queryString(
+            name="OVEHOSTED_STORAGE_NVMEOF_NQN",
+            note=_("Please specify the NVMe-oF subsystem NQN: "),
+            prompt=True,
+            caseSensitive=True,
+        )
+
+    def _query_nvmeof_lunid(self, address, port, nqn):
+        nvmeof_getdevices_vars = {
+            "he_fqdn": self.environment[
+                ohostedcons.NetworkEnv.OVIRT_HOSTED_ENGINE_FQDN
+            ],
+            "he_host_name": self.environment[ohostedcons.EngineEnv.APP_HOST_NAME],
+            "he_admin_password": self.environment[ohostedcons.EngineEnv.ADMIN_PASSWORD],
+            "he_admin_username": self.environment[ohostedcons.EngineEnv.ADMIN_USERNAME],
+            "he_nvmeof_address": address,
+            "he_nvmeof_port": port,
+            "he_nvmeof_nqn": nqn,
+        }
+        ah = ansible_utils.AnsibleHelper(
+            tags=ohostedcons.Const.HE_TAG_NVMEOF_GETDEVICES,
+            extra_vars=nvmeof_getdevices_vars,
+            user_extra_vars=self.environment.get(
+                ohostedcons.CoreEnv.ANSIBLE_USER_EXTRA_VARS
+            ),
+        )
+        self.logger.info(_("Getting NVMe-oF namespace list"))
+        r = ah.run()
+        self.logger.debug(r)
+        available_luns = []
+        if "otopi_nvmeof_devices" in r:
+            if (
+                "ansible_facts" in r["otopi_nvmeof_devices"]
+                and "ovirt_host_storages" in r["otopi_nvmeof_devices"]["ansible_facts"]
             ):
-                available_luns = r['otopi_fc_devices']['ovirt_host_storages']
+                available_luns = r["otopi_nvmeof_devices"]["ansible_facts"][
+                    "ovirt_host_storages"
+                ]
+            elif "ovirt_host_storages" in r["otopi_nvmeof_devices"]:
+                available_luns = r["otopi_nvmeof_devices"]["ovirt_host_storages"]
         return self._select_lun(available_luns)
 
     def _select_lun(self, available_luns):
         self.logger.debug(available_luns)
         if len(available_luns) == 0:
-            msg = _('Cannot find any LUN on the selected target')
+            msg = _("Cannot find any LUN on the selected target")
             self.logger.error(msg)
             raise RuntimeError(msg)
 
         f_luns = []
-        lun_list = ''
-        available_luns = sorted(available_luns, key=lambda lun: lun['id'])
+        lun_list = ""
+        available_luns = sorted(available_luns, key=lambda lun: lun["id"])
         self.logger.debug(available_luns)
         # TODO: enforce free and minimum free space
         for entry in available_luns:
-            paths = entry['logical_units'][0]['paths']
+            paths = entry["logical_units"][0]["paths"]
             f_luns.append(
                 {
-                    'index': str(len(f_luns)+1),
-                    'id': entry['id'],
-                    'capacityGiB': int(
-                        entry['logical_units'][0]['size']
-                    ) / pow(2, 30),
-                    'vendorID': entry['logical_units'][0]['vendor_id'],
-                    'productID': entry['logical_units'][0]['product_id'],
-                    'status': entry['logical_units'][0]['status'],
-                    'paths': paths,
-                    'discard_max_size': int(entry['logical_units'][0]
-                                            ['discard_max_size'])
+                    "index": str(len(f_luns) + 1),
+                    "id": entry["id"],
+                    "capacityGiB": int(entry["logical_units"][0]["size"]) / pow(2, 30),
+                    "vendorID": entry["logical_units"][0]["vendor_id"],
+                    "productID": entry["logical_units"][0]["product_id"],
+                    "status": entry["logical_units"][0]["status"],
+                    "paths": paths,
+                    "discard_max_size": int(
+                        entry["logical_units"][0]["discard_max_size"]
+                    ),
                 }
             )
         for entry in f_luns:
             lun_list += _(
-                '\t[{i}]\t{id}\t{capacityGiB}GiB\t{vendorID}\t{productID}\n'
-                '\t\tstatus: {status}, paths: {ap} active'
+                "\t[{i}]\t{id}\t{capacityGiB}GiB\t{vendorID}\t{productID}\n"
+                "\t\tstatus: {status}, paths: {ap} active"
             ).format(
-                i=entry['index'],
-                id=entry['id'],
-                capacityGiB=entry['capacityGiB'],
-                vendorID=entry['vendorID'],
-                productID=entry['productID'],
-                status=entry['status'],
-                ap=entry['paths'],
+                i=entry["index"],
+                id=entry["id"],
+                capacityGiB=entry["capacityGiB"],
+                vendorID=entry["vendorID"],
+                productID=entry["productID"],
+                status=entry["status"],
+                ap=entry["paths"],
             )
-            lun_list += '\n\n'
+            lun_list += "\n\n"
 
         self.dialog.note(
             _(
-                'The following luns have been found on the requested target:\n'
-                '{lun_list}'
+                "The following luns have been found on the requested target:\n"
+                "{lun_list}"
             ).format(
                 lun_list=lun_list,
             )
         )
         slun = self.dialog.queryString(
-            name='OVEHOSTED_STORAGE_BLOCKD_LUN',
-            note=_(
-                'Please select the destination LUN '
-                '(@VALUES@) [@DEFAULT@]: '
-            ),
+            name="OVEHOSTED_STORAGE_BLOCKD_LUN",
+            note=_("Please select the destination LUN (@VALUES@) [@DEFAULT@]: "),
             prompt=True,
             caseSensitive=True,
-            default='1',
-            validValues=[i['index'] for i in f_luns],
+            default="1",
+            validValues=[i["index"] for i in f_luns],
         )
-        return f_luns[int(slun)-1]
+        return f_luns[int(slun) - 1]
 
     @plugin.event(
         stage=plugin.Stages.STAGE_INIT,
     )
     def _init(self):
+        self.environment.setdefault(ohostedcons.StorageEnv.NFS_VERSION, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.DOMAIN_TYPE, None)
         self.environment.setdefault(
-            ohostedcons.StorageEnv.NFS_VERSION,
-            None
+            ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION, None
         )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.DOMAIN_TYPE,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.MNT_OPTIONS,
-            None
-        )
+        self.environment.setdefault(ohostedcons.StorageEnv.MNT_OPTIONS, None)
         self.environment.setdefault(
             ohostedcons.StorageEnv.STORAGE_DOMAIN_NAME,
-            ohostedcons.Defaults.DEFAULT_STORAGE_DOMAIN_NAME
+            ohostedcons.Defaults.DEFAULT_STORAGE_DOMAIN_NAME,
         )
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_IP_ADDR, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_PORT, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_PORTAL, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_USER, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_PASSWORD, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_DISCOVER_USER, None)
         self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_IP_ADDR,
-            None
+            ohostedcons.StorageEnv.ISCSI_DISCOVER_PASSWORD, None
         )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_PORT,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_PORTAL,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_USER,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_PASSWORD,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_DISCOVER_USER,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_DISCOVER_PASSWORD,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.ISCSI_TARGET,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.LUN_ID,
-            None
-        )
-        self.environment.setdefault(
-            ohostedcons.StorageEnv.DISCARD_SUPPORT,
-            False
-        )
+        self.environment.setdefault(ohostedcons.StorageEnv.ISCSI_TARGET, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.LUN_ID, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.DISCARD_SUPPORT, False)
+        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_NQN, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_ADDR, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_PORT, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_HOST_NQN, None)
+        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_DHCHAP_KEY, None)
 
     @plugin.event(
         stage=plugin.Stages.STAGE_CLOSEUP,
@@ -553,30 +541,17 @@ class Plugin(plugin.PluginBase):
         created = False
         interactive = True
         if (
-            self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION
-            ] is not None or
-            self.environment[ohostedcons.StorageEnv.MNT_OPTIONS] is not None or
-            self.environment[ohostedcons.StorageEnv.NFS_VERSION] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.ISCSI_IP_ADDR
-            ] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.ISCSI_PORT
-            ] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.ISCSI_USER
-            ] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.ISCSI_PASSWORD
-            ] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.ISCSI_TARGET
-            ] is not None or
-            self.environment[
-                ohostedcons.StorageEnv.ISCSI_TARGET
-            ] is not None
+            self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE] is not None
+            or self.environment[ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION]
+            is not None
+            or self.environment[ohostedcons.StorageEnv.MNT_OPTIONS] is not None
+            or self.environment[ohostedcons.StorageEnv.NFS_VERSION] is not None
+            or self.environment[ohostedcons.StorageEnv.ISCSI_IP_ADDR] is not None
+            or self.environment[ohostedcons.StorageEnv.ISCSI_PORT] is not None
+            or self.environment[ohostedcons.StorageEnv.ISCSI_USER] is not None
+            or self.environment[ohostedcons.StorageEnv.ISCSI_PASSWORD] is not None
+            or self.environment[ohostedcons.StorageEnv.ISCSI_TARGET] is not None
+            or self.environment[ohostedcons.StorageEnv.ISCSI_TARGET] is not None
         ):
             interactive = False
         while not created:
@@ -586,46 +561,35 @@ class Plugin(plugin.PluginBase):
             ]
             storage_domain_address = None
             storage_domain_path = None
-            mnt_options = self.environment[
-                ohostedcons.StorageEnv.MNT_OPTIONS
-            ]
-            nfs_version = self.environment[
-                ohostedcons.StorageEnv.NFS_VERSION
-            ]
-            iscsi_portal = self.environment[
-                ohostedcons.StorageEnv.ISCSI_IP_ADDR
-            ]
-            iscsi_port = self.environment[
-                ohostedcons.StorageEnv.ISCSI_PORT
-            ]
-            iscsi_username = self.environment[
-                ohostedcons.StorageEnv.ISCSI_USER
-            ]
-            iscsi_password = self.environment[
-                ohostedcons.StorageEnv.ISCSI_PASSWORD
-            ]
+            mnt_options = self.environment[ohostedcons.StorageEnv.MNT_OPTIONS]
+            nfs_version = self.environment[ohostedcons.StorageEnv.NFS_VERSION]
+            iscsi_portal = self.environment[ohostedcons.StorageEnv.ISCSI_IP_ADDR]
+            iscsi_port = self.environment[ohostedcons.StorageEnv.ISCSI_PORT]
+            iscsi_username = self.environment[ohostedcons.StorageEnv.ISCSI_USER]
+            iscsi_password = self.environment[ohostedcons.StorageEnv.ISCSI_PASSWORD]
             iscsi_discover_username = self.environment[
                 ohostedcons.StorageEnv.ISCSI_DISCOVER_USER
             ]
             iscsi_discover_password = self.environment[
                 ohostedcons.StorageEnv.ISCSI_DISCOVER_PASSWORD
             ]
-            iscsi_target = self.environment[
-                ohostedcons.StorageEnv.ISCSI_TARGET
-            ]
-            lunid = self.environment[
-                ohostedcons.StorageEnv.LUN_ID
-            ]
-            discard = self.environment[
-                ohostedcons.StorageEnv.DISCARD_SUPPORT
+            iscsi_target = self.environment[ohostedcons.StorageEnv.ISCSI_TARGET]
+            lunid = self.environment[ohostedcons.StorageEnv.LUN_ID]
+            discard = self.environment[ohostedcons.StorageEnv.DISCARD_SUPPORT]
+            nvmeof_nqn = self.environment[ohostedcons.StorageEnv.NVMEOF_NQN]
+            nvmeof_address = self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR]
+            nvmeof_port = self.environment[ohostedcons.StorageEnv.NVMEOF_PORT]
+            nvmeof_host_nqn = self.environment[ohostedcons.StorageEnv.NVMEOF_HOST_NQN]
+            nvmeof_dhchap_key = self.environment[
+                ohostedcons.StorageEnv.NVMEOF_DHCHAP_KEY
             ]
 
             if domain_type is None:
                 domain_type = self.dialog.queryString(
-                    name='OVEHOSTED_STORAGE_DOMAIN_TYPE',
+                    name="OVEHOSTED_STORAGE_DOMAIN_TYPE",
                     note=_(
-                        'Please specify the storage '
-                        'you would like to use (@VALUES@)[@DEFAULT@]: '
+                        "Please specify the storage "
+                        "you would like to use (@VALUES@)[@DEFAULT@]: "
                     ),
                     prompt=True,
                     caseSensitive=True,
@@ -633,6 +597,7 @@ class Plugin(plugin.PluginBase):
                         ohostedcons.DomainTypes.GLUSTERFS,
                         ohostedcons.DomainTypes.ISCSI,
                         ohostedcons.DomainTypes.FC,
+                        ohostedcons.DomainTypes.NVMEOF,
                         ohostedcons.DomainTypes.NFS,
                     ),
                     default=ohostedcons.DomainTypes.NFS,
@@ -640,24 +605,24 @@ class Plugin(plugin.PluginBase):
             else:
                 if domain_type == ohostedcons.DomainTypes.NFS3:
                     domain_type = ohostedcons.DomainTypes.NFS
-                    self.environment[
-                        ohostedcons.StorageEnv.NFS_VERSION
-                    ] = ohostedcons.NfsVersions.V3
+                    self.environment[ohostedcons.StorageEnv.NFS_VERSION] = (
+                        ohostedcons.NfsVersions.V3
+                    )
                 elif domain_type == ohostedcons.DomainTypes.NFS4:
                     domain_type = ohostedcons.DomainTypes.NFS
-                    self.environment[
-                        ohostedcons.StorageEnv.NFS_VERSION
-                    ] = ohostedcons.NfsVersions.V4
+                    self.environment[ohostedcons.StorageEnv.NFS_VERSION] = (
+                        ohostedcons.NfsVersions.V4
+                    )
 
             if domain_type == ohostedcons.DomainTypes.NFS:
                 if nfs_version is None:
                     nfs_version = self._query_nfs_version()
 
             if (
-                domain_type == ohostedcons.DomainTypes.NFS or
-                domain_type == ohostedcons.DomainTypes.GLUSTERFS
+                domain_type == ohostedcons.DomainTypes.NFS
+                or domain_type == ohostedcons.DomainTypes.GLUSTERFS
             ):
-                path_test = '^(.+):/(.+)$'
+                path_test = "^(.+):/(.+)$"
                 if storage_domain_connection is None:
                     storage_domain_connection = self._query_connection_path()
                 pmatch = re.match(path_test, storage_domain_connection.strip())
@@ -666,19 +631,14 @@ class Plugin(plugin.PluginBase):
                     t_storage_domain_address = pmatch.group(1)
                     t_storage_domain_path = pmatch.group(2)
                     valid = True
-                    if (
-                        ':' in t_storage_domain_address and
-                        (
-                            t_storage_domain_address[0] != '[' or
-                            t_storage_domain_address[-1] != ']'
-                        )
+                    if ":" in t_storage_domain_address and (
+                        t_storage_domain_address[0] != "["
+                        or t_storage_domain_address[-1] != "]"
                     ):
                         valid = False
 
                 if not valid:
-                    msg = _(
-                        'Invalid connection path: {p}'
-                    ).format(
+                    msg = _("Invalid connection path: {p}").format(
                         p=storage_domain_connection,
                     )
                     self.logger.error(msg)
@@ -686,7 +646,7 @@ class Plugin(plugin.PluginBase):
                         raise RuntimeError(msg)
                     continue
                 storage_domain_address = t_storage_domain_address
-                storage_domain_path = '/{p}'.format(p=t_storage_domain_path)
+                storage_domain_path = "/{p}".format(p=t_storage_domain_path)
 
                 if mnt_options is None:
                     mnt_options = self._query_mnt_options(mnt_options)
@@ -697,32 +657,25 @@ class Plugin(plugin.PluginBase):
                 if iscsi_port is None:
                     iscsi_port = self._query_iscsi_port()
                 if iscsi_discover_username is None:
-                    iscsi_discover_username = self._query_iscsi_username(
-                        discover=True
-                    )
+                    iscsi_discover_username = self._query_iscsi_username(discover=True)
                 if iscsi_discover_password is None:
-                    iscsi_discover_password = self._query_iscsi_password(
-                        discover=True
-                    )
+                    iscsi_discover_password = self._query_iscsi_password(discover=True)
                 if iscsi_username is None:
-                    iscsi_username = self._query_iscsi_username(
-                        discover=False
-                    )
+                    iscsi_username = self._query_iscsi_username(discover=False)
                 if iscsi_password is None:
-                    iscsi_password = self._query_iscsi_password(
-                        discover=False
-                    )
+                    iscsi_password = self._query_iscsi_password(discover=False)
                 if iscsi_target is None:
                     try:
-                        iscsi_target, iscsi_tpgt, iscsi_portal, iscsi_port = \
+                        iscsi_target, iscsi_tpgt, iscsi_portal, iscsi_port = (
                             self._query_iscsi_target(
                                 discover_username=iscsi_discover_username,
                                 discover_password=iscsi_discover_password,
                                 portal=iscsi_portal,
                                 port=iscsi_port,
                             )
+                        )
                     except RuntimeError as e:
-                        self.logger.error(_('Unable to get target list'))
+                        self.logger.error(_("Unable to get target list"))
                         if not interactive:
                             raise e
                         continue
@@ -734,76 +687,105 @@ class Plugin(plugin.PluginBase):
                             portal=iscsi_portal,
                             port=iscsi_port,
                             target=iscsi_target,
-                            tpgt=iscsi_tpgt
+                            tpgt=iscsi_tpgt,
                         )
-                        lunid = lun['id']
-                        discard = lun['discard_max_size'] > 0
+                        lunid = lun["id"]
+                        discard = lun["discard_max_size"] > 0
                         self.logger.info(
                             _("iSCSI discard after delete is {v}").format(
                                 v=_("enabled") if discard else _("disabled")
                             )
                         )
                     except RuntimeError as e:
-                        self.logger.error(_('Unable to get target list'))
+                        self.logger.error(_("Unable to get target list"))
                         if not interactive:
                             raise e
                         continue
 
-                storage_domain_address = iscsi_portal.split(',')[0]
+                storage_domain_address = iscsi_portal.split(",")[0]
 
             elif domain_type == ohostedcons.DomainTypes.FC:
                 if lunid is None:
                     try:
                         lun = self._query_fc_lunid()
-                        lunid = lun['id']
-                        discard = lun['discard_max_size'] > 0
+                        lunid = lun["id"]
+                        discard = lun["discard_max_size"] > 0
                         self.logger.info(
                             _("FC discard after delete is {v}").format(
                                 v=_("enabled") if discard else _("disabled")
                             )
                         )
                     except RuntimeError as e:
-                        self.logger.error(_('Unable to get target list'))
+                        self.logger.error(_("Unable to get target list"))
                         if not interactive:
                             raise e
                         continue
 
+            elif domain_type == ohostedcons.DomainTypes.NVMEOF:
+                if nvmeof_address is None:
+                    nvmeof_address = self._query_nvmeof_address()
+                if nvmeof_port is None:
+                    nvmeof_port = self._query_nvmeof_port()
+                if nvmeof_nqn is None:
+                    nvmeof_nqn = self._query_nvmeof_nqn()
+                if lunid is None:
+                    try:
+                        lun = self._query_nvmeof_lunid(
+                            address=nvmeof_address,
+                            port=nvmeof_port,
+                            nqn=nvmeof_nqn,
+                        )
+                        lunid = lun["id"]
+                        discard = lun["discard_max_size"] > 0
+                        self.logger.info(
+                            _("NVMe-oF discard after delete is {v}").format(
+                                v=_("enabled") if discard else _("disabled")
+                            )
+                        )
+                    except RuntimeError as e:
+                        self.logger.error(_("Unable to get NVMe-oF namespace list"))
+                        if not interactive:
+                            raise e
+                        continue
+                storage_domain_address = nvmeof_address
+
             else:
-                self.logger.error(_('Currently not implemented'))
+                self.logger.error(_("Currently not implemented"))
                 if not interactive:
-                    raise RuntimeError('Currently not implemented')
+                    raise RuntimeError("Currently not implemented")
                 continue
 
             storage_domain_vars = {
-                'he_fqdn': self.environment[
+                "he_fqdn": self.environment[
                     ohostedcons.NetworkEnv.OVIRT_HOSTED_ENGINE_FQDN
                 ],
-                'he_host_name': self.environment[
-                    ohostedcons.EngineEnv.APP_HOST_NAME
-                ],
-                'he_admin_password': self.environment[
+                "he_host_name": self.environment[ohostedcons.EngineEnv.APP_HOST_NAME],
+                "he_admin_password": self.environment[
                     ohostedcons.EngineEnv.ADMIN_PASSWORD
                 ],
-                'he_admin_username': self.environment[
+                "he_admin_username": self.environment[
                     ohostedcons.EngineEnv.ADMIN_USERNAME
                 ],
-                'he_local_vm_dir': self.environment[
-                    ohostedcons.CoreEnv.LOCAL_VM_DIR
-                ],
-                'he_storage_domain_name': self.environment[
+                "he_local_vm_dir": self.environment[ohostedcons.CoreEnv.LOCAL_VM_DIR],
+                "he_storage_domain_name": self.environment[
                     ohostedcons.StorageEnv.STORAGE_DOMAIN_NAME
                 ],
-                'he_storage_domain_addr': storage_domain_address,
-                'he_storage_domain_path': storage_domain_path,
-                'he_mount_options': mnt_options,
-                'he_nfs_version': nfs_version,
-                'he_domain_type': domain_type,
-                'he_iscsi_portal_port': iscsi_port,
-                'he_iscsi_target': iscsi_target,
-                'he_lun_id': lunid,
-                'he_iscsi_username': iscsi_username,
-                'he_iscsi_password': iscsi_password,
-                'he_discard': discard,
+                "he_storage_domain_addr": storage_domain_address,
+                "he_storage_domain_path": storage_domain_path,
+                "he_mount_options": mnt_options,
+                "he_nfs_version": nfs_version,
+                "he_domain_type": domain_type,
+                "he_iscsi_portal_port": iscsi_port,
+                "he_iscsi_target": iscsi_target,
+                "he_lun_id": lunid,
+                "he_iscsi_username": iscsi_username,
+                "he_iscsi_password": iscsi_password,
+                "he_discard": discard,
+                "he_nvmeof_address": nvmeof_address,
+                "he_nvmeof_port": nvmeof_port,
+                "he_nvmeof_nqn": nvmeof_nqn,
+                "he_nvmeof_host_nqn": nvmeof_host_nqn,
+                "he_nvmeof_dhchap_key": nvmeof_dhchap_key,
             }
             ah = ansible_utils.AnsibleHelper(
                 tags=ohostedcons.Const.HE_TAG_CREATE_SD,
@@ -812,16 +794,14 @@ class Plugin(plugin.PluginBase):
                     ohostedcons.CoreEnv.ANSIBLE_USER_EXTRA_VARS
                 ),
             )
-            self.logger.info(_('Creating Storage Domain'))
+            self.logger.info(_("Creating Storage Domain"))
             try:
                 r = ah.run()
             except RuntimeError as e:
                 if not interactive:
                     raise e
                 continue
-            self.logger.debug(
-                'Create storage domain results {r}'.format(r=r)
-            )
+            self.logger.debug("Create storage domain results {r}".format(r=r))
             # We had very few reports [1] where 'Activate Storage Domain'
             # finished successfully and returned to us
             # 'otopi_storage_domain_details' that includes 'storagedomain',
@@ -837,113 +817,137 @@ class Plugin(plugin.PluginBase):
             # and having to start from scratch.
             # [1] https://bugzilla.redhat.com/show_bug.cgi?id=1662657
             if (
-                'otopi_storage_domain_details' in r and
-                'storagedomain' in r['otopi_storage_domain_details'] and
-                'available' in r[
-                    'otopi_storage_domain_details'
-                ]['storagedomain']
+                "otopi_storage_domain_details" in r
+                and "storagedomain" in r["otopi_storage_domain_details"]
+                and "available" in r["otopi_storage_domain_details"]["storagedomain"]
             ):
-                storage_domain = r[
-                    'otopi_storage_domain_details'
-                ]['storagedomain']
-                self.environment[
-                    ohostedcons.StorageEnv.BDEVICE_SIZE_GB
-                ] = int(storage_domain['available'])/1024/1024/1024
-                if storage_domain['status'] == 'active':
+                storage_domain = r["otopi_storage_domain_details"]["storagedomain"]
+                self.environment[ohostedcons.StorageEnv.BDEVICE_SIZE_GB] = (
+                    int(storage_domain["available"]) / 1024 / 1024 / 1024
+                )
+                if storage_domain["status"] == "active":
                     created = True
                     # and set all the env values from the response
-                    storage = storage_domain['storage']
-                    storage_type = storage['type']
+                    storage = storage_domain["storage"]
+                    storage_type = storage["type"]
                     if storage_type == "fcp":
                         storage_type = "fc"  # Normalize type for HE broker.
-                    self.environment[
-                        ohostedcons.StorageEnv.DOMAIN_TYPE
-                    ] = storage_type
-                    if self.environment[
-                        ohostedcons.StorageEnv.DOMAIN_TYPE
-                    ] == ohostedcons.DomainTypes.NFS:
+                    self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE] = storage_type
+                    if (
+                        self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE]
+                        == ohostedcons.DomainTypes.NFS
+                    ):
                         # workaround for https://bugzilla.redhat.com/1688982
-                        address = storage['address']
+                        address = storage["address"]
                         if ":" in address and address[0] != "[":
                             address = "[{a}]".format(a=address)
 
                         self.environment[
                             ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION
-                        ] = '{address}:{path}'.format(
+                        ] = "{address}:{path}".format(
                             address=address,
-                            path=storage['path'],
+                            path=storage["path"],
                         )
                         # TODO: any way to get it from the engine
-                        self.environment[
-                            ohostedcons.StorageEnv.MNT_OPTIONS
-                        ] = mnt_options
-                        self.environment[
-                            ohostedcons.StorageEnv.NFS_VERSION
-                        ] = storage['nfs_version']
-                    if self.environment[
-                        ohostedcons.StorageEnv.DOMAIN_TYPE
-                    ] == ohostedcons.DomainTypes.GLUSTERFS:
+                        self.environment[ohostedcons.StorageEnv.MNT_OPTIONS] = (
+                            mnt_options
+                        )
+                        self.environment[ohostedcons.StorageEnv.NFS_VERSION] = storage[
+                            "nfs_version"
+                        ]
+                    if (
+                        self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE]
+                        == ohostedcons.DomainTypes.GLUSTERFS
+                    ):
                         self.environment[
                             ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION
-                        ] = '{address}:{path}'.format(
-                            address=storage['address'],
-                            path=storage['path'],
+                        ] = "{address}:{path}".format(
+                            address=storage["address"],
+                            path=storage["path"],
                         )
-                        self.environment[
-                            ohostedcons.StorageEnv.MNT_OPTIONS
-                        ] = mnt_options
-                    if self.environment[
-                        ohostedcons.StorageEnv.DOMAIN_TYPE
-                    ] == ohostedcons.DomainTypes.ISCSI:
+                        self.environment[ohostedcons.StorageEnv.MNT_OPTIONS] = (
+                            mnt_options
+                        )
+                    if (
+                        self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE]
+                        == ohostedcons.DomainTypes.ISCSI
+                    ):
                         self.logger.info(
-                            _('iSCSI connected paths: {n}').format(
-                                n=len(storage['volume_group']['logical_units'])
+                            _("iSCSI connected paths: {n}").format(
+                                n=len(storage["volume_group"]["logical_units"])
+                            )
+                        )
+                        self.environment[ohostedcons.StorageEnv.ISCSI_PORTAL] = storage[
+                            "volume_group"
+                        ]["logical_units"][0]["portal"].split(",")[1]
+                        lun0 = storage["volume_group"]["logical_units"][0]
+                        self.environment[ohostedcons.StorageEnv.ISCSI_IP_ADDR] = (
+                            ",".join(
+                                [
+                                    x["address"]
+                                    for x in storage["volume_group"]["logical_units"]
+                                ]
                             )
                         )
                         self.environment[
-                            ohostedcons.StorageEnv.ISCSI_PORTAL
-                        ] = storage['volume_group']['logical_units'][
-                            0
-                        ]['portal'].split(',')[1]
-                        lun0 = storage['volume_group']['logical_units'][0]
-                        self.environment[
-                            ohostedcons.StorageEnv.ISCSI_IP_ADDR
-                        ] = ','.join([x['address'] for x in storage[
-                            'volume_group'
-                        ]['logical_units']])
+                            ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION
+                        ] = self.environment[ohostedcons.StorageEnv.ISCSI_IP_ADDR]
+                        self.environment[ohostedcons.StorageEnv.ISCSI_PORT] = ",".join(
+                            [
+                                str(x["port"])
+                                for x in storage["volume_group"]["logical_units"]
+                            ]
+                        )
+                        self.environment[ohostedcons.StorageEnv.ISCSI_TARGET] = lun0[
+                            "target"
+                        ]
+                        self.environment[ohostedcons.StorageEnv.LUN_ID] = lun0["id"]
+                        self.environment[ohostedcons.StorageEnv.ISCSI_USER] = (
+                            iscsi_username
+                        )
+                        self.environment[ohostedcons.StorageEnv.ISCSI_PASSWORD] = (
+                            iscsi_password
+                        )
+                    if (
+                        self.environment[ohostedcons.StorageEnv.DOMAIN_TYPE]
+                        == ohostedcons.DomainTypes.NVMEOF
+                    ):
+                        self.logger.info(
+                            _("NVMe-oF connected paths: {n}").format(
+                                n=len(storage["volume_group"]["logical_units"])
+                            )
+                        )
+                        lun0 = storage["volume_group"]["logical_units"][0]
+                        self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR] = ",".join(
+                            [
+                                x["address"]
+                                for x in storage["volume_group"]["logical_units"]
+                            ]
+                        )
                         self.environment[
                             ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION
-                        ] = self.environment[
-                            ohostedcons.StorageEnv.ISCSI_IP_ADDR
+                        ] = self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR]
+                        self.environment[ohostedcons.StorageEnv.NVMEOF_PORT] = ",".join(
+                            [
+                                str(x["port"])
+                                for x in storage["volume_group"]["logical_units"]
+                            ]
+                        )
+                        self.environment[ohostedcons.StorageEnv.NVMEOF_NQN] = lun0[
+                            "nqn"
                         ]
-                        self.environment[
-                            ohostedcons.StorageEnv.ISCSI_PORT
-                        ] = ','.join([str(x['port']) for x in storage[
-                            'volume_group'
-                        ]['logical_units']])
-                        self.environment[
-                            ohostedcons.StorageEnv.ISCSI_TARGET
-                        ] = lun0['target']
-                        self.environment[
-                            ohostedcons.StorageEnv.LUN_ID
-                        ] = lun0['id']
-                        self.environment[
-                            ohostedcons.StorageEnv.ISCSI_USER
-                        ] = iscsi_username
-                        self.environment[
-                            ohostedcons.StorageEnv.ISCSI_PASSWORD
-                        ] = iscsi_password
+                        self.environment[ohostedcons.StorageEnv.LUN_ID] = lun0["id"]
                 else:
                     if not interactive:
-                        raise RuntimeError('Failed creating storage domain')
+                        raise RuntimeError("Failed creating storage domain")
             else:
                 if not interactive:
-                    raise RuntimeError('Failed creating storage domain')
+                    raise RuntimeError("Failed creating storage domain")
             if not created:
                 self.logger.error(
                     _(
-                        'There was some problem with the storage domain, '
-                        'please try again'
+                        "There was some problem with the storage domain, "
+                        "please try again"
                     )
                 )
 

--- a/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
+++ b/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
@@ -551,7 +551,9 @@ class Plugin(plugin.PluginBase):
             or self.environment[ohostedcons.StorageEnv.ISCSI_USER] is not None
             or self.environment[ohostedcons.StorageEnv.ISCSI_PASSWORD] is not None
             or self.environment[ohostedcons.StorageEnv.ISCSI_TARGET] is not None
-            or self.environment[ohostedcons.StorageEnv.ISCSI_TARGET] is not None
+            or self.environment[ohostedcons.StorageEnv.NVMEOF_NQN] is not None
+            or self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR] is not None
+            or self.environment[ohostedcons.StorageEnv.NVMEOF_PORT] is not None
         ):
             interactive = False
         while not created:

--- a/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
+++ b/src/plugins/gr-he-ansiblesetup/core/storage_domain.py
@@ -426,15 +426,16 @@ class Plugin(plugin.PluginBase):
         self.logger.debug(r)
         available_luns = []
         if "otopi_nvmeof_devices" in r:
-            if (
-                "ansible_facts" in r["otopi_nvmeof_devices"]
-                and "ovirt_host_storages" in r["otopi_nvmeof_devices"]["ansible_facts"]
-            ):
-                available_luns = r["otopi_nvmeof_devices"]["ansible_facts"][
+            if "ansible_facts" in r["otopi_nvmeof_devices"]:
+                nvmeof_devices = r["otopi_nvmeof_devices"]
+                if "ovirt_host_storages" in nvmeof_devices["ansible_facts"]:
+                    available_luns = nvmeof_devices["ansible_facts"][
+                        "ovirt_host_storages"
+                    ]
+            elif "ovirt_host_storages" in r["otopi_nvmeof_devices"]:
+                available_luns = r["otopi_nvmeof_devices"][
                     "ovirt_host_storages"
                 ]
-            elif "ovirt_host_storages" in r["otopi_nvmeof_devices"]:
-                available_luns = r["otopi_nvmeof_devices"]["ovirt_host_storages"]
         return self._select_lun(available_luns)
 
     def _select_lun(self, available_luns):
@@ -527,8 +528,12 @@ class Plugin(plugin.PluginBase):
         self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_NQN, None)
         self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_ADDR, None)
         self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_PORT, None)
-        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_HOST_NQN, None)
-        self.environment.setdefault(ohostedcons.StorageEnv.NVMEOF_DHCHAP_KEY, None)
+        self.environment.setdefault(
+            ohostedcons.StorageEnv.NVMEOF_HOST_NQN, None
+        )
+        self.environment.setdefault(
+            ohostedcons.StorageEnv.NVMEOF_DHCHAP_KEY, None
+        )
 
     @plugin.event(
         stage=plugin.Stages.STAGE_CLOSEUP,
@@ -578,10 +583,18 @@ class Plugin(plugin.PluginBase):
             iscsi_target = self.environment[ohostedcons.StorageEnv.ISCSI_TARGET]
             lunid = self.environment[ohostedcons.StorageEnv.LUN_ID]
             discard = self.environment[ohostedcons.StorageEnv.DISCARD_SUPPORT]
-            nvmeof_nqn = self.environment[ohostedcons.StorageEnv.NVMEOF_NQN]
-            nvmeof_address = self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR]
-            nvmeof_port = self.environment[ohostedcons.StorageEnv.NVMEOF_PORT]
-            nvmeof_host_nqn = self.environment[ohostedcons.StorageEnv.NVMEOF_HOST_NQN]
+            nvmeof_nqn = self.environment[
+                ohostedcons.StorageEnv.NVMEOF_NQN
+            ]
+            nvmeof_address = self.environment[
+                ohostedcons.StorageEnv.NVMEOF_ADDR
+            ]
+            nvmeof_port = self.environment[
+                ohostedcons.StorageEnv.NVMEOF_PORT
+            ]
+            nvmeof_host_nqn = self.environment[
+                ohostedcons.StorageEnv.NVMEOF_HOST_NQN
+            ]
             nvmeof_dhchap_key = self.environment[
                 ohostedcons.StorageEnv.NVMEOF_DHCHAP_KEY
             ]
@@ -920,24 +933,26 @@ class Plugin(plugin.PluginBase):
                             )
                         )
                         lun0 = storage["volume_group"]["logical_units"][0]
-                        self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR] = ",".join(
-                            [
-                                x["address"]
-                                for x in storage["volume_group"]["logical_units"]
-                            ]
+                        addrs = ",".join(
+                            x["address"]
+                            for x in storage["volume_group"]["logical_units"]
+                        )
+                        ports = ",".join(
+                            str(x["port"])
+                            for x in storage["volume_group"]["logical_units"]
                         )
                         self.environment[
+                            ohostedcons.StorageEnv.NVMEOF_ADDR
+                        ] = addrs
+                        self.environment[
                             ohostedcons.StorageEnv.STORAGE_DOMAIN_CONNECTION
-                        ] = self.environment[ohostedcons.StorageEnv.NVMEOF_ADDR]
-                        self.environment[ohostedcons.StorageEnv.NVMEOF_PORT] = ",".join(
-                            [
-                                str(x["port"])
-                                for x in storage["volume_group"]["logical_units"]
-                            ]
-                        )
-                        self.environment[ohostedcons.StorageEnv.NVMEOF_NQN] = lun0[
-                            "nqn"
-                        ]
+                        ] = addrs
+                        self.environment[
+                            ohostedcons.StorageEnv.NVMEOF_PORT
+                        ] = ports
+                        self.environment[
+                            ohostedcons.StorageEnv.NVMEOF_NQN
+                        ] = lun0["nqn"]
                         self.environment[ohostedcons.StorageEnv.LUN_ID] = lun0["id"]
                 else:
                     if not interactive:

--- a/src/plugins/gr-he-ansiblesetup/core/target_vm.py
+++ b/src/plugins/gr-he-ansiblesetup/core/target_vm.py
@@ -164,6 +164,21 @@ class Plugin(plugin.PluginBase):
             'he_lun_id': self.environment[
                 ohostedcons.StorageEnv.LUN_ID
             ],
+            'he_nvmeof_address': self.environment[
+                ohostedcons.StorageEnv.NVMEOF_ADDR
+            ],
+            'he_nvmeof_port': self.environment[
+                ohostedcons.StorageEnv.NVMEOF_PORT
+            ],
+            'he_nvmeof_nqn': self.environment[
+                ohostedcons.StorageEnv.NVMEOF_NQN
+            ],
+            'he_nvmeof_host_nqn': self.environment[
+                ohostedcons.StorageEnv.NVMEOF_HOST_NQN
+            ],
+            'he_nvmeof_dhchap_key': self.environment[
+                ohostedcons.StorageEnv.NVMEOF_DHCHAP_KEY
+            ],
             'he_cdrom_uuid': self.environment[ohostedcons.VMEnv.CDROM_UUID],
             'he_nic_uuid': self.environment[ohostedcons.VMEnv.NIC_UUID],
             'he_maxvcpus': self.environment[ohostedcons.VMEnv.MAXVCPUS],

--- a/templates/hosted-engine.conf.in
+++ b/templates/hosted-engine.conf.in
@@ -29,3 +29,10 @@ portal=@PORTAL@
 user=@USER@
 password=@PASSWORD@
 port=@PORT@
+
+# The following are used only for NVMe-oF storage
+nvmeof_address=@NVMEOF_ADDR@
+nvmeof_port=@NVMEOF_PORT@
+nvmeof_nqn=@NVMEOF_NQN@
+nvmeof_host_nqn=@NVMEOF_HOST_NQN@
+nvmeof_dhchap_key=@NVMEOF_DHCHAP_KEY@


### PR DESCRIPTION
Add NVMe-oF/TCP storage domain support to oVirt. This is a block/shared storage domain type, analogous to iSCSI, using the built-in Linux NVMe 
initiator (nvme-cli). It supports both authenticated (DH-HMAC-CHAP) and non-authenticated NVMe-oF targets.

The feature try to be backend-agnostic for any NVMe/TCP target works (Ceph NVMe-oF Gateway is the reference implementation).

# Change :
- New storage domain type: nvmeof in REST API / Ansible / SDK
- Authentication : optional DH-HMAC-CHAP 
- Multipath : native NVMe multipath detected automatically; falls back to dm-mpath
- Host deployment: NVMe host NQN auto-detected from /etc/nvme/hostnqn

# Limitations :
- No iSCSI bond support for NVMe-oF
- NVMe-oF storage domain cannot be edited or imported via webadmin
